### PR TITLE
Задание 11 : Обновление локаций у Department

### DIFF
--- a/DirectoryService/.editorconfig
+++ b/DirectoryService/.editorconfig
@@ -242,6 +242,7 @@ tab_width = 4
 #CUSTOM
 
 #STYLE COP ANALYZERS
+dotnet_diagnostic.CA1034.severity = none
 dotnet_diagnostic.CA1308.severity = none
 dotnet_diagnostic.CA1822.severity = none
 dotnet_diagnostic.CA1000.severity = none

--- a/DirectoryService/src/DirectoryService.Application/Database/ITransactionManager.cs
+++ b/DirectoryService/src/DirectoryService.Application/Database/ITransactionManager.cs
@@ -1,0 +1,10 @@
+﻿using CSharpFunctionalExtensions;
+using General.Errors;
+
+namespace DirectoryService.Application.Database;
+
+public interface ITransactionManager
+{
+    Task<Result<ITransactionScope, Failure>> BeginTransactionAsync(CancellationToken cancellationToken);
+    Task<UnitResult<Failure>> SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/DirectoryService/src/DirectoryService.Application/Database/ITransactionScope.cs
+++ b/DirectoryService/src/DirectoryService.Application/Database/ITransactionScope.cs
@@ -1,0 +1,10 @@
+using CSharpFunctionalExtensions;
+using General.Errors;
+
+namespace DirectoryService.Application.Database;
+
+public interface ITransactionScope : IAsyncDisposable
+{
+    Task<UnitResult<Failure>> CommitAsync(CancellationToken cancellationToken);
+    Task<UnitResult<Failure>> RollbackAsync(CancellationToken cancellationToken);
+}

--- a/DirectoryService/src/DirectoryService.Application/Departments/CreateDepartmentHandler.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/CreateDepartmentHandler.cs
@@ -1,9 +1,11 @@
 ﻿using CSharpFunctionalExtensions;
 using DirectoryService.Application.Abstractions;
+using DirectoryService.Application.Database;
 using DirectoryService.Application.Departments.Interfaces;
 using DirectoryService.Application.Locations.Interfaces;
 using DirectoryService.Application.Validation;
 using DirectoryService.Contracts.Departments;
+using DirectoryService.Domain.Common.DomainEntityErrors;
 using DirectoryService.Domain.Departments;
 using DirectoryService.Domain.ValueObjects;
 using FluentValidation;
@@ -16,17 +18,20 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
 {
     private readonly IDepartmentsRepository _departmentsRepository;
     private readonly ILocationsRepository _locationsRepository;
+    private readonly ITransactionManager _transactionManager;
     private readonly ILogger<CreateDepartmentHandler> _logger;
     private readonly IValidator<CreateDepartmentRequest> _validator;
 
     public CreateDepartmentHandler(
         IDepartmentsRepository departmentsRepository,
         ILocationsRepository locationsRepository,
+        ITransactionManager transactionManager,
         ILogger<CreateDepartmentHandler> logger,
         IValidator<CreateDepartmentRequest> validator)
     {
         _departmentsRepository = departmentsRepository;
         _locationsRepository = locationsRepository;
+        _transactionManager = transactionManager;
         _logger = logger;
         _validator = validator;
     }
@@ -49,8 +54,7 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
         // Бизнес валдидация
         if (command.Request.ParentId is not null && parent is null)
         {
-            return Failure
-                .NotFoundEntity("Department not found", command.Request.ParentId.Value, "department.not.found")
+            return DepartmentErrors.NotFound(command.Request.ParentId.Value)
                 .ToFailList();
         }
 
@@ -58,9 +62,9 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
             command.Request.LocationIds,
             l => command.Request.LocationIds.Contains(l.Id),
             cancellationToken);
-        
+
         if (!allLocationExist)
-            return Failure.NotFoundCollectionEntity($"One or more locations not found : {string.Join(',', command.Request.LocationIds)}", "locations.not.found").ToFailList();
+            return LocationErrors.CollectionNotFound(command.Request.LocationIds).ToFailList();
         
         // Coздание доменных моделей
         Guid departmentID = Guid.NewGuid();
@@ -76,12 +80,13 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
             return department.Error;
         
         // Сохранение доменных моделей в БД
-        var adding = await _departmentsRepository.AddAsync(department.Value, cancellationToken);
+        var id = await _departmentsRepository.AddAsync(department.Value, cancellationToken);
 
-        if (adding.IsFailure)
-            return adding.Error.ToFailList();
+        var saving = await _transactionManager.SaveChangesAsync(cancellationToken);
+        if (saving.IsFailure)
+            return saving.Error.ToFailList();
 
-        return departmentID;
+        return id;
 
     }
 }

--- a/DirectoryService/src/DirectoryService.Application/Departments/CreateDepartmentValidator.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/CreateDepartmentValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using DirectoryService.Application.Validation;
 using DirectoryService.Contracts.Departments;
+using DirectoryService.Domain.Common;
 using DirectoryService.Domain.ValueObjects;
 using FluentValidation;
 using General.Errors;
@@ -17,8 +18,8 @@ public class CreateDepartmentValidator: AbstractValidator<CreateDepartmentReques
 
         RuleFor(d => d.LocationIds)
             .NotEmpty()
-            .WithError(Failure.Validation("The collection should not be empty.", "location-id.collection.invalid"))
+            .WithError(CommonErrors.CollectionEmpty("location-id"))
             .AllUnique()
-            .WithError(Failure.Validation("All items in the collection must be unique.", "location-id.collection.invalid"));
+            .WithError(CommonErrors.UniqueCollectionInvalid("location-id"));
     }
 }

--- a/DirectoryService/src/DirectoryService.Application/Departments/Interfaces/IDepartmentsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/Interfaces/IDepartmentsRepository.cs
@@ -7,7 +7,7 @@ namespace DirectoryService.Application.Departments.Interfaces;
 
 public interface IDepartmentsRepository
 {
-    Task<Result<Guid, Failure>> AddAsync(Department department, CancellationToken cancellationToken);
+    Task<Guid> AddAsync(Department department, CancellationToken cancellationToken);
         
     Task<Department?> GetByAsync(Expression<Func<Department, bool>> expression, CancellationToken cancellationToken);
 
@@ -16,7 +16,18 @@ public interface IDepartmentsRepository
     Task<bool> AllMatchAsync(IEnumerable<Guid> ids, Expression<Func<Department, bool>> expression,
         CancellationToken cancellationToken);
 
-    Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken);
-    
+    Task<UnitResult<Failure>> DeleteDepartmentLocationsByIdAsync(Guid departmentId, CancellationToken cancellationToken);
+
+    Task<Guid> AddDepartmentLocationsAsync(
+        IEnumerable<DepartmentLocation> departmentLocations,
+        CancellationToken cancellationToken);
+
+    Task<Guid> AddDepartmentLocationsAsync(
+        Guid departmentId,
+        IEnumerable<Guid> locationIds,
+        CancellationToken cancellationToken);
+
+    // Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken);
+
     // Task<Guid> DeleteAsync(Guid departmentId, CancellationToken cancellationToken);
 }

--- a/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsCommand.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsCommand.cs
@@ -1,0 +1,6 @@
+﻿using DirectoryService.Application.Abstractions;
+using DirectoryService.Contracts.Departments;
+
+namespace DirectoryService.Application.Departments;
+
+public record UpdateDepartmentLocationsCommand(Guid DepartmentId, UpdateDepartmentLocationsRequest Request) : ICommand;

--- a/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsHandler.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsHandler.cs
@@ -1,0 +1,97 @@
+﻿using CSharpFunctionalExtensions;
+using DirectoryService.Application.Abstractions;
+using DirectoryService.Application.Database;
+using DirectoryService.Application.Departments.Interfaces;
+using DirectoryService.Application.Locations.Interfaces;
+using DirectoryService.Application.Validation;
+using DirectoryService.Contracts.Departments;
+using DirectoryService.Domain.Common.DomainEntityErrors;
+using DirectoryService.Domain.Departments;
+using FluentValidation;
+using General.Errors;
+using Microsoft.Extensions.Logging;
+
+namespace DirectoryService.Application.Departments;
+
+public class UpdateDepartmentLocationsHandler : ICommandHandler<Guid, UpdateDepartmentLocationsCommand>
+{
+    private readonly IDepartmentsRepository _departmentsRepository;
+    private readonly ILocationsRepository _locationsRepository;
+    private readonly ITransactionManager _transactionManager;
+    private readonly IValidator<UpdateDepartmentLocationsRequest> _validator;
+    private readonly ILogger<UpdateDepartmentLocationsHandler> _logger;
+
+    public UpdateDepartmentLocationsHandler(
+        IDepartmentsRepository departmentsRepository,
+        ILocationsRepository locationsRepository,
+        ITransactionManager transactionManager,
+        IValidator<UpdateDepartmentLocationsRequest> validator,
+        ILogger<UpdateDepartmentLocationsHandler> logger)
+    {
+        _departmentsRepository = departmentsRepository;
+        _locationsRepository = locationsRepository;
+        _transactionManager = transactionManager;
+        _validator = validator;
+        _logger = logger;
+    }
+    
+    public async Task<Result<Guid, FailList>> Handle(
+        UpdateDepartmentLocationsCommand command,
+        CancellationToken cancellationToken)
+    {
+        // Валидация входных параметров
+        var validationResult = await _validator.ValidateAsync(command.Request, cancellationToken);
+
+        if (!validationResult.IsValid)
+            return validationResult.ToFailList();
+        
+        // Создание транзакции
+        var createScope = await _transactionManager.BeginTransactionAsync(cancellationToken);
+        if (createScope.IsFailure)
+            return createScope.Error.ToFailList();
+
+        await using var transaction = createScope.Value;
+
+        // Бизнес валидация
+        bool allLocationsExist = await _locationsRepository.AllMatchAsync(
+            command.Request.LocationIds,
+            l => command.Request.LocationIds.Contains(l.Id), 
+            cancellationToken);
+
+        if (!allLocationsExist)
+            return LocationErrors.CollectionNotFound(command.Request.LocationIds).ToFailList();
+
+        Department? department = await 
+            _departmentsRepository.GetByAsync(d => d.Id == command.DepartmentId, cancellationToken);
+        
+        if(department is null)
+            return DepartmentErrors.NotFound(command.DepartmentId).ToFailList();
+        
+        // Обновление локаций
+        var delete =
+            await _departmentsRepository.DeleteDepartmentLocationsByIdAsync(command.DepartmentId, cancellationToken);
+
+        if (delete.IsFailure)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return delete.Error.ToFailList();
+        }
+
+        department.UpdateLocations(command.Request.LocationIds);
+        
+        var saveChanges = await _transactionManager.SaveChangesAsync(cancellationToken);
+
+        if (saveChanges.IsFailure)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return saveChanges.Error.ToFailList();
+        }
+        
+        var commit = await transaction.CommitAsync(cancellationToken);
+        
+        if (commit.IsFailure)
+            return commit.Error.ToFailList();
+
+        return command.DepartmentId;
+    }
+}

--- a/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsValidator.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsValidator.cs
@@ -1,0 +1,18 @@
+﻿using DirectoryService.Application.Validation;
+using DirectoryService.Contracts.Departments;
+using DirectoryService.Domain.Common;
+using FluentValidation;
+
+namespace DirectoryService.Application.Departments;
+
+public class UpdateDepartmentLocationsValidator: AbstractValidator<UpdateDepartmentLocationsRequest>
+{
+    public UpdateDepartmentLocationsValidator()
+    {
+        RuleFor(r => r.LocationIds)
+            .NotEmpty()
+            .WithError(CommonErrors.CollectionEmpty("location-id"))
+            .AllUnique()
+            .WithError(CommonErrors.UniqueCollectionInvalid("location-id"));
+    }
+}

--- a/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsValidator.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsValidator.cs
@@ -2,6 +2,7 @@
 using DirectoryService.Contracts.Departments;
 using DirectoryService.Domain.Common;
 using FluentValidation;
+using General.Errors;
 
 namespace DirectoryService.Application.Departments;
 
@@ -9,6 +10,12 @@ public class UpdateDepartmentLocationsValidator: AbstractValidator<UpdateDepartm
 {
     public UpdateDepartmentLocationsValidator()
     {
+        RuleFor(r => r).NotNull().WithError(Failure.Error(
+                                                          "Invalid Request", "request.invalid"));
+
+        RuleForEach(r => r.LocationIds).NotEqual(Guid.Empty)
+            .WithError(CommonErrors.CollectionItemsInvalid("Location-id"));
+        
         RuleFor(r => r.LocationIds)
             .NotEmpty()
             .WithError(CommonErrors.CollectionEmpty("location-id"))

--- a/DirectoryService/src/DirectoryService.Application/Locations/CreateLocationHandler.cs
+++ b/DirectoryService/src/DirectoryService.Application/Locations/CreateLocationHandler.cs
@@ -1,8 +1,10 @@
 ﻿using CSharpFunctionalExtensions;
 using DirectoryService.Application.Abstractions;
+using DirectoryService.Application.Database;
 using DirectoryService.Application.Locations.Interfaces;
 using DirectoryService.Application.Validation;
 using DirectoryService.Contracts.Locations;
+using DirectoryService.Domain.Common.DomainEntityErrors;
 using DirectoryService.Domain.Locations;
 using DirectoryService.Domain.ValueObjects;
 using FluentValidation;
@@ -15,15 +17,18 @@ namespace DirectoryService.Application.Locations;
 public class CreateLocationHandler: ICommandHandler<Guid, CreateLocationCommand>
 {
     private readonly ILocationsRepository _repository;
+    private readonly ITransactionManager _transactionManager;
     private readonly ILogger<CreateLocationHandler> _logger;
     private readonly IValidator<CreateLocationRequest> _validator;
 
     public CreateLocationHandler(
-        ILocationsRepository repository, 
+        ILocationsRepository repository,
+        ITransactionManager transactionManager,
         ILogger<CreateLocationHandler> logger,
         IValidator<CreateLocationRequest> validator)
     {
         _repository = repository;
+        _transactionManager = transactionManager;
         _logger = logger;
         _validator = validator;
     }
@@ -36,8 +41,6 @@ public class CreateLocationHandler: ICommandHandler<Guid, CreateLocationCommand>
         if (!validationResult.IsValid)
         {
             var errors = validationResult.ToFailList();
-            
-            // _logger.LogError("Validation failed: {Errors}", errors);
             return errors;
         }
         
@@ -55,7 +58,7 @@ public class CreateLocationHandler: ICommandHandler<Guid, CreateLocationCommand>
         bool nameExist = await _repository.IsMatchAsync(l => l.LocationName == name.Value, cancellationToken);
         
         if (nameExist)
-            return Failure.Conflict($"Location with this Name already exists : {name.Value.Value}", "location-name.conflict").ToFailList();
+            return LocationErrors.PropertyConflict(name.Value.Value, "Name").ToFailList();
         
         bool addressExist = await _repository.IsMatchAsync(
             l => l.Address.Country == address.Value.Country &&
@@ -66,7 +69,7 @@ public class CreateLocationHandler: ICommandHandler<Guid, CreateLocationCommand>
             cancellationToken);
         
         if (addressExist)
-            return Failure.Conflict($"Location with this address already exists : {address.Value}", "location-address.conflict").ToFailList();
+            return LocationErrors.PropertyConflict(address.Error.ToString(), "Address").ToFailList();
         
         // Coздание доменных моделей
         var location = Location.Create(name.Value, address.Value, timezone.Value);
@@ -75,10 +78,12 @@ public class CreateLocationHandler: ICommandHandler<Guid, CreateLocationCommand>
             return location.Error.ToFailList();
         
         // Сохранение доменных моделей в БД
-        var adding = await _repository.AddAsync(location.Value, cancellationToken);
-        if (adding.IsFailure)
-            return adding.Error.ToFailList();
+        var id = await _repository.AddAsync(location.Value, cancellationToken);
         
-        return adding.Value;
+        var saving = await _transactionManager.SaveChangesAsync(cancellationToken);
+        if (saving.IsFailure)
+            return saving.Error.ToFailList();
+        
+        return id;
     }
 }

--- a/DirectoryService/src/DirectoryService.Application/Locations/Interfaces/ILocationsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Application/Locations/Interfaces/ILocationsRepository.cs
@@ -8,7 +8,7 @@ namespace DirectoryService.Application.Locations.Interfaces;
 
 public interface ILocationsRepository
 {
-    Task<Result<Guid, Failure>> AddAsync(Location location, CancellationToken cancellationToken);
+    Task<Guid> AddAsync(Location location, CancellationToken cancellationToken);
     
     Task<Location?> GetByAsync(Expression<Func<Location, bool>> expression, CancellationToken cancellationToken);
     
@@ -16,7 +16,7 @@ public interface ILocationsRepository
     
     Task<bool> AllMatchAsync(IEnumerable<Guid> ids, Expression<Func<Location, bool>> expression, CancellationToken cancellationToken);
     
-    Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken);
+    // Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken);
     
     // Task<Guid> DeleteAsync(Guid locationId, CancellationToken cancellationToken);
     //

--- a/DirectoryService/src/DirectoryService.Application/Positions/CreatePositionHandler.cs
+++ b/DirectoryService/src/DirectoryService.Application/Positions/CreatePositionHandler.cs
@@ -1,10 +1,12 @@
 ﻿using CSharpFunctionalExtensions;
 using DirectoryService.Application.Abstractions;
+using DirectoryService.Application.Database;
 using DirectoryService.Application.Departments.Interfaces;
 using DirectoryService.Application.Positions.Interfaces;
 using DirectoryService.Application.Validation;
 using DirectoryService.Contracts;
 using DirectoryService.Contracts.Positions;
+using DirectoryService.Domain.Common.DomainEntityErrors;
 using DirectoryService.Domain.Departments;
 using DirectoryService.Domain.Positions;
 using DirectoryService.Domain.ValueObjects;
@@ -18,17 +20,20 @@ public class CreatePositionHandler : ICommandHandler<Guid, CreatePositionCommand
 {
     private readonly IPositionsRepository _positionsRepository;
     private readonly IDepartmentsRepository _departmentsRepository;
+    private readonly ITransactionManager _transactionManager;
     private readonly ILogger<CreatePositionHandler> _logger;
     private readonly IValidator<CreatePositionRequest> _validator;
 
     public CreatePositionHandler(
         IPositionsRepository positionsRepository,
         IDepartmentsRepository departmentsRepository,
+        ITransactionManager transactionManager,
         ILogger<CreatePositionHandler> logger,
         IValidator<CreatePositionRequest> validator) 
     {
         _positionsRepository = positionsRepository;
         _departmentsRepository = departmentsRepository;
+        _transactionManager = transactionManager;
         _logger = logger;
         _validator = validator;
     }
@@ -49,7 +54,7 @@ public class CreatePositionHandler : ICommandHandler<Guid, CreatePositionCommand
             cancellationToken);
         
         if (activePosWithNameExist)
-            return Failure.Conflict($"Position with this Name already exists : {name.Value.Value}", "position-name.conflict").ToFailList();
+            return PositionErrors.PropertyConflict(name.Value.Value, "Name").ToFailList();
 
         bool allDepartmentsExist = await _departmentsRepository.AllMatchAsync(
             command.Request.DepartmentIds,
@@ -57,7 +62,7 @@ public class CreatePositionHandler : ICommandHandler<Guid, CreatePositionCommand
             cancellationToken);
         
         if(!allDepartmentsExist)
-            return Failure.NotFoundCollectionEntity($"One or more departments not found : {string.Join(',', command.Request.DepartmentIds)}", "departments.not.found").ToFailList();
+            return DepartmentErrors.CollectionNotFound(command.Request.DepartmentIds).ToFailList();
 
         bool allDepartmentsActive = await _departmentsRepository.AllMatchAsync(
             command.Request.DepartmentIds,
@@ -65,7 +70,7 @@ public class CreatePositionHandler : ICommandHandler<Guid, CreatePositionCommand
             cancellationToken);
         
         if (!allDepartmentsActive)
-            return Failure.Conflict($"One or more departments are inactive : {string.Join(',', command.Request.DepartmentIds)}", "departments.inactive").ToFailList();
+            return DepartmentErrors.CollectionInactive(command.Request.DepartmentIds).ToFailList();
         
         // Coздание доменных моделей
         Guid positionId = Guid.NewGuid();
@@ -78,11 +83,12 @@ public class CreatePositionHandler : ICommandHandler<Guid, CreatePositionCommand
             return position.Error.ToFailList();
 
         // Сохранение доменных моделей в БД
-        var adding = await _positionsRepository.AddAsync(position.Value, cancellationToken);
+        var id = await _positionsRepository.AddAsync(position.Value, cancellationToken);
 
-        if (adding.IsFailure)
-            return adding.Error.ToFailList();
+        var saving = await _transactionManager.SaveChangesAsync(cancellationToken);
+        if (saving.IsFailure)
+            return saving.Error.ToFailList();
 
-        return adding.Value;
+        return id;
     }
 }

--- a/DirectoryService/src/DirectoryService.Application/Positions/CreatePositionValidator.cs
+++ b/DirectoryService/src/DirectoryService.Application/Positions/CreatePositionValidator.cs
@@ -14,6 +14,9 @@ public class CreatePositionValidator: AbstractValidator<CreatePositionRequest>
     public CreatePositionValidator()
     {
         RuleFor(p => p.Name).MustBeValueObject(PositionName.Create);
+        RuleForEach(r => r.DepartmentIds).NotEqual(Guid.Empty)
+            .WithError(CommonErrors.CollectionItemsInvalid("Department-id"));
+        
         RuleFor(p => p.DepartmentIds)
             .NotEmpty()
             .WithError(CommonErrors.CollectionEmpty("department-id"))

--- a/DirectoryService/src/DirectoryService.Application/Positions/CreatePositionValidator.cs
+++ b/DirectoryService/src/DirectoryService.Application/Positions/CreatePositionValidator.cs
@@ -1,6 +1,7 @@
 ﻿using DirectoryService.Application.Validation;
 using DirectoryService.Contracts;
 using DirectoryService.Contracts.Positions;
+using DirectoryService.Domain.Common;
 using DirectoryService.Domain.Common.Constants;
 using DirectoryService.Domain.ValueObjects;
 using FluentValidation;
@@ -15,9 +16,9 @@ public class CreatePositionValidator: AbstractValidator<CreatePositionRequest>
         RuleFor(p => p.Name).MustBeValueObject(PositionName.Create);
         RuleFor(p => p.DepartmentIds)
             .NotEmpty()
-            .WithError(Failure.Validation("The collection should not be empty.", "department-id.collection.invalid"))
+            .WithError(CommonErrors.CollectionEmpty("department-id"))
             .AllUnique()
-            .WithError(Failure.Validation("All items in the collection must be unique.", "department-id.collection.invalid"));
+            .WithError(CommonErrors.UniqueCollectionInvalid("department-id"));
 
         RuleFor(p => p.Description).MaximumLength(LengthConstants.MAX_LENGTH_1000).WithError(
             Failure.Validation(

--- a/DirectoryService/src/DirectoryService.Application/Positions/Interfaces/IPositionsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Application/Positions/Interfaces/IPositionsRepository.cs
@@ -8,7 +8,7 @@ namespace DirectoryService.Application.Positions.Interfaces;
 
 public interface IPositionsRepository
 {
-    Task<Result<Guid, Failure>> AddAsync(Position position, CancellationToken cancellationToken);
+    Task<Guid> AddAsync(Position position, CancellationToken cancellationToken);
 
     Task<Position?> GetByAsync(Expression<Func<Position, bool>> expression, CancellationToken cancellationToken);
 
@@ -17,7 +17,7 @@ public interface IPositionsRepository
     Task<bool> AllMatchAsync(IEnumerable<Guid> ids, Expression<Func<Position, bool>> expression,
         CancellationToken cancellationToken);
     
-    Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken);
+    // Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken);
       
     // Task<Guid> DeleteAsync(Guid positionId, CancellationToken cancellationToken);
     

--- a/DirectoryService/src/DirectoryService.Contracts/Departments/UpdateDepartmentLocationsRequest.cs
+++ b/DirectoryService/src/DirectoryService.Contracts/Departments/UpdateDepartmentLocationsRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace DirectoryService.Contracts.Departments;
+
+public record UpdateDepartmentLocationsRequest(IReadOnlyList<Guid> LocationIds);

--- a/DirectoryService/src/DirectoryService.Domain/Common/CommonErrors.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Common/CommonErrors.cs
@@ -40,6 +40,10 @@ public static class CommonErrors
             $"One or more {entity} are inactive: {string.Join(", ", ids)}",
             $"{entity.ToLower(CultureInfo.InvariantCulture)}.inactive");
 
+    public static Failure CollectionItemsInvalid(string collectionName) => Failure.Validation(
+        $"Collection '{collectionName}' contains invalid items.",
+        $"{collectionName.ToLower(CultureInfo.InvariantCulture)}.collection.invalid");
+    
     public static Failure UniqueCollectionInvalid(string collectionName) => Failure.Validation(
             "All items in the collection must be unique.",
             $"{collectionName.ToLower(CultureInfo.InvariantCulture)}.collection.invalid");

--- a/DirectoryService/src/DirectoryService.Domain/Common/CommonErrors.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Common/CommonErrors.cs
@@ -1,0 +1,48 @@
+﻿using System.Globalization;
+using General.Errors;
+
+namespace DirectoryService.Domain.Common;
+
+public static class CommonErrors
+{
+    public static Failure InternalError =>
+        Failure.Error("Something went wrong", "server.internal");
+
+    public static Failure EntityNotFound(string entity, Guid id) =>
+        Failure.NotFoundEntity(
+            $"{entity} not found",
+            id,
+            $"{entity.ToLower(CultureInfo.InvariantCulture)}.not_found");
+
+    public static Failure EntityCollectionNotFound(string entity, IEnumerable<Guid> ids) =>
+        Failure.NotFoundCollectionEntity(
+            $"One or more {entity} not found: {string.Join(", ", ids)}",
+            $"{entity.ToLower(CultureInfo.InvariantCulture)}.not_found");
+
+    public static Failure EntityConflictProperty(string entity, string property, string value) =>
+        Failure.Conflict(
+            $"{entity} with {property} '{value}' already exists",
+            $"{entity.ToLower(CultureInfo.InvariantCulture)}.{property.ToLower(CultureInfo.InvariantCulture)}.conflict");
+    
+    public static Failure EntityConflict(string entity, Guid id) =>
+        Failure.ConflictEntity(
+            $"{entity} already exists",
+            $"{entity.ToLower(CultureInfo.InvariantCulture)}.{entity.ToLower(CultureInfo.InvariantCulture)}.conflict",
+            id);
+    
+    public static Failure EntityInactive(string entity, Guid id) =>
+        Failure.Conflict(
+            $"{entity} with id '{id}' is inactive",
+            $"{entity.ToLower(CultureInfo.InvariantCulture)}.inactive");
+
+    public static Failure EntityCollectionInactive(string entity, IEnumerable<Guid> ids) =>
+        Failure.Conflict(
+            $"One or more {entity} are inactive: {string.Join(", ", ids)}",
+            $"{entity.ToLower(CultureInfo.InvariantCulture)}.inactive");
+
+    public static Failure UniqueCollectionInvalid(string collectionName) => Failure.Validation(
+            "All items in the collection must be unique.",
+            $"{collectionName.ToLower(CultureInfo.InvariantCulture)}.collection.invalid");
+    public static Failure CollectionEmpty(string collectionName) => Failure.Validation("The collection should not be empty.", $"{collectionName.ToLower(CultureInfo.InvariantCulture)}.collection.invalid");
+    
+}

--- a/DirectoryService/src/DirectoryService.Domain/Common/DomainEntityErrors/DepartmentErrors.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Common/DomainEntityErrors/DepartmentErrors.cs
@@ -1,0 +1,27 @@
+using General.Errors;
+
+namespace DirectoryService.Domain.Common.DomainEntityErrors;
+
+public static class DepartmentErrors
+{
+    private const string Entity = "Department";
+    private const string EntityPlural = "Departments";
+
+    public static Failure NotFound(Guid departmentId) =>
+        CommonErrors.EntityNotFound(Entity, departmentId);
+
+    public static Failure CollectionNotFound(IEnumerable<Guid> departmentIds) =>
+        CommonErrors.EntityCollectionNotFound(EntityPlural, departmentIds);
+
+    public static Failure PropertyConflict(string value, string property = "") =>
+        CommonErrors.EntityConflictProperty(Entity, property, value);
+    
+    public static Failure EntityConflict(Guid id) =>
+        CommonErrors.EntityConflict(Entity, id);
+
+    public static Failure Inactive(Guid departmentId) =>
+        CommonErrors.EntityInactive(Entity, departmentId);
+
+    public static Failure CollectionInactive(IEnumerable<Guid> departmentIds) =>
+        CommonErrors.EntityCollectionInactive(EntityPlural, departmentIds);
+}

--- a/DirectoryService/src/DirectoryService.Domain/Common/DomainEntityErrors/LocationErrors.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Common/DomainEntityErrors/LocationErrors.cs
@@ -1,0 +1,27 @@
+using General.Errors;
+
+namespace DirectoryService.Domain.Common.DomainEntityErrors;
+
+public static class LocationErrors
+{
+    private const string Entity = "Location";
+    private const string EntityPlural = "Locations";
+
+    public static Failure NotFound(Guid locationId) =>
+        CommonErrors.EntityNotFound(Entity, locationId);
+
+    public static Failure CollectionNotFound(IEnumerable<Guid> locationIds) =>
+        CommonErrors.EntityCollectionNotFound(EntityPlural, locationIds);
+
+    public static Failure PropertyConflict(string value, string property = "") =>
+        CommonErrors.EntityConflictProperty(Entity, property, value);
+    
+    public static Failure EntityConflict(Guid id) =>
+        CommonErrors.EntityConflict(Entity, id);
+
+    public static Failure Inactive(Guid locationId) =>
+        CommonErrors.EntityInactive(Entity, locationId);
+
+    public static Failure CollectionInactive(IEnumerable<Guid> locationIds) =>
+        CommonErrors.EntityCollectionInactive(EntityPlural, locationIds);
+}

--- a/DirectoryService/src/DirectoryService.Domain/Common/DomainEntityErrors/PositionErrors.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Common/DomainEntityErrors/PositionErrors.cs
@@ -1,0 +1,27 @@
+using General.Errors;
+
+namespace DirectoryService.Domain.Common.DomainEntityErrors;
+
+public static class PositionErrors
+{
+    private const string Entity = "Position";
+    private const string EntityPlural = "Positions";
+
+    public static Failure NotFound(Guid positionId) =>
+        CommonErrors.EntityNotFound(Entity, positionId);
+
+    public static Failure CollectionNotFound(IEnumerable<Guid> positionIds) =>
+        CommonErrors.EntityCollectionNotFound(EntityPlural, positionIds);
+
+    public static Failure PropertyConflict(string value, string property = "") =>
+        CommonErrors.EntityConflictProperty(Entity, property, value);
+
+    public static Failure EntityConflict(Guid id) =>
+        CommonErrors.EntityConflict(Entity, id);
+    
+    public static Failure Inactive(Guid positionId) =>
+        CommonErrors.EntityInactive(Entity, positionId);
+
+    public static Failure CollectionInactive(IEnumerable<Guid> positionIds) =>
+        CommonErrors.EntityCollectionInactive(EntityPlural, positionIds);
+}

--- a/DirectoryService/src/DirectoryService.Domain/Departments/Department.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Departments/Department.cs
@@ -59,13 +59,6 @@ public class Department
         Parent = parent;
     }
     
-    // public static Result<Department, Failure> Create(DepartmentName departmentName, Identifier identifier, Path path, short depth, Guid? id = null, Guid? parentId = null)
-    // {
-    //     DateTime now = DateTime.UtcNow;
-    //     
-    //     return new Department(id ?? Guid.NewGuid(), departmentName, identifier, parentId, path, depth, true, now, now);
-    //     
-    // }
     public static Result<Department, FailList> CreateParent(
         DepartmentName departmentName,
         Identifier identifier,
@@ -89,36 +82,28 @@ public class Department
         short depth = (short)(parent.Depth + 1);
         return new Department(id ?? Guid.NewGuid(), departmentName, identifier, path, depth, true, departmentLocations, now, now, parent);
     }
-    
-    public Department AddLocations(params Guid[] locationIds)
-    {
-        foreach (Guid id in locationIds)
-        {
-            if(id != Guid.Empty && !CheckLocation(id))
-                _departmentLocations.Add(new DepartmentLocation(Id, id));
-        }
 
-        return this;
+    public void UpdateLocations(IEnumerable<Guid> locationIds)
+    {
+        var list = locationIds.Select(id => new DepartmentLocation(Id, id));
+        _departmentLocations.Clear();
+        _departmentLocations.AddRange(list);
     }
     
-    public Department AddPositions(params Guid[] positionIds)
+    /// <summary>
+    /// Обновляет коллекцию локаций департамента.
+    /// </summary>
+    /// <param name="departmentLocations">Новый список локаций.</param>
+    /// <remarks>
+    /// При передаче сущностей с заполненным Id EF Core пометит их как <c>Modified</c>
+    /// и сгенерирует UPDATE вместо INSERT. Если соответствующих записей в БД не существует —
+    /// выбрасывается <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>.
+    /// Используй конструктор без Id либо добавляй записи напрямую через DbSet.AddRangeAsync.
+    /// </remarks>
+    public void UpdateLocations(IEnumerable<DepartmentLocation> departmentLocations)
     {
-        foreach (Guid id in positionIds)
-        {
-            if(id != Guid.Empty && !CheckPosition(id))
-                _departmentPositions.Add(new DepartmentPosition(Id, id));
-        }
-
-        return this;
+        _departmentLocations.Clear();
+        _departmentLocations.AddRange(departmentLocations);
     }
     
-    private bool CheckLocation(Guid id)
-    {
-        return _departmentLocations.Any(dl => dl.LocationId == id);
-    }
-
-    private bool CheckPosition(Guid id)
-    {
-        return _departmentPositions.Any(dp => dp.PositionId == id);
-    }
-}
+ }

--- a/DirectoryService/src/DirectoryService.Domain/Departments/DepartmentLocation.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Departments/DepartmentLocation.cs
@@ -6,9 +6,16 @@ public sealed class DepartmentLocation
     public Guid DepartmentId { get; private set; }
     public Guid LocationId { get; private set; }
 
+    public DepartmentLocation(Guid id, Guid departmentId, Guid locationId)
+    {
+        Id = id;
+        DepartmentId = departmentId;
+        LocationId = locationId;
+    }
+    
     public DepartmentLocation(Guid departmentId, Guid locationId)
     {
-        Id = Guid.NewGuid();
+        Id = Guid.Empty;
         DepartmentId = departmentId;
         LocationId = locationId;
     }

--- a/DirectoryService/src/DirectoryService.Domain/Departments/DepartmentPosition.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Departments/DepartmentPosition.cs
@@ -6,9 +6,16 @@ public sealed class DepartmentPosition
     public Guid DepartmentId { get; private set; }
     public Guid PositionId { get; private set; }
 
+    public DepartmentPosition(Guid id, Guid departmentId, Guid positionId)
+    {
+        Id = id;
+        DepartmentId = departmentId;
+        PositionId = positionId;
+    }
+    
     public DepartmentPosition(Guid departmentId, Guid positionId)
     {
-        Id = Guid.NewGuid();
+        Id = Guid.Empty;
         DepartmentId = departmentId;
         PositionId = positionId;
     }

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Configurations/InfrastructureDependencyInjection.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Configurations/InfrastructureDependencyInjection.cs
@@ -1,8 +1,10 @@
 ﻿using DirectoryService.Application.Configuration;
+using DirectoryService.Application.Database;
 using DirectoryService.Application.Departments.Interfaces;
 using DirectoryService.Application.Locations.Interfaces;
 using DirectoryService.Application.Positions.Interfaces;
 using DirectoryService.Domain.Common.Constants;
+using DirectoryService.Infrastructure.Database;
 using DirectoryService.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -40,6 +42,8 @@ public static class InfrastructureDependencyInjection
             options.UseLoggerFactory(loggerFactory);
         });
 
+        services.AddScoped<ITransactionManager, TransactionManager>();
+        
         return services;
     }
     

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Database/TransactionManager.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Database/TransactionManager.cs
@@ -1,0 +1,59 @@
+﻿using CSharpFunctionalExtensions;
+using DirectoryService.Application.Database;
+using DirectoryService.Domain.Common;
+using General.Errors;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace DirectoryService.Infrastructure.Database;
+
+public class TransactionManager: ITransactionManager
+{
+    private readonly DirectoryServiceDbContext _dbContext;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<TransactionManager> _logger;
+
+    public TransactionManager(
+        DirectoryServiceDbContext dbContext, 
+        ILoggerFactory loggerFactory)
+    {
+        _dbContext = dbContext;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<TransactionManager>();
+    }
+
+    public async Task<Result<ITransactionScope, Failure>> BeginTransactionAsync(
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+            var scopeLogger = _loggerFactory.CreateLogger<TransactionScope>();
+            
+#pragma warning disable CA2000
+            var scope = new TransactionScope(transaction.GetDbTransaction(), scopeLogger);
+#pragma warning restore CA2000
+
+            return scope;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to begin transaction");
+            return CommonErrors.InternalError;
+        }
+    }
+
+    public async Task<UnitResult<Failure>> SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return UnitResult.Success<Failure>();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to save changes");
+            return UnitResult.Failure(CommonErrors.InternalError);
+        }
+    }
+}

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Database/TransactionScope.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Database/TransactionScope.cs
@@ -1,0 +1,73 @@
+﻿using System.Data;
+using System.Data.Common;
+using CSharpFunctionalExtensions;
+using DirectoryService.Application.Database;
+using DirectoryService.Domain.Common;
+using General.Errors;
+using Microsoft.Extensions.Logging;
+
+namespace DirectoryService.Infrastructure.Database;
+
+public class TransactionScope : ITransactionScope
+{
+    private readonly DbTransaction _transaction;
+    private readonly ILogger<TransactionScope> _logger;
+    private bool _disposed;
+
+    public TransactionScope(DbTransaction transaction, ILogger<TransactionScope> logger)
+    {
+        _transaction = transaction;
+        _logger = logger;
+    }
+
+    public async Task<UnitResult<Failure>> CommitAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _transaction.CommitAsync(cancellationToken);
+            return UnitResult.Success<Failure>();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to commit transaction");
+            return UnitResult.Failure(CommonErrors.InternalError);
+        }
+    }
+
+    public async Task<UnitResult<Failure>> RollbackAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+           await _transaction.RollbackAsync(cancellationToken);
+            return UnitResult.Success<Failure>();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to rollback transaction");
+            return UnitResult.Failure(CommonErrors.InternalError);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        await _transaction.DisposeAsync();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        
+        // GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing)
+            _transaction.Dispose();
+        _disposed = true;
+    }
+}

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/DirectoryServiceDbContext.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/DirectoryServiceDbContext.cs
@@ -23,5 +23,7 @@ public class DirectoryServiceDbContext : DbContext
     public DbSet<Location> Locations => Set<Location>();
 
     public DbSet<Position> Positions => Set<Position>();
-    
+
+    public DbSet<DepartmentLocation> DepartmentLocations => Set<DepartmentLocation>();
+
 }

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/EntityConfigurations/DepartmentLocationConfiguration.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/EntityConfigurations/DepartmentLocationConfiguration.cs
@@ -13,7 +13,11 @@ public class DepartmentLocationConfiguration: IEntityTypeConfiguration<Departmen
 
         builder.HasKey(dl => dl.Id).HasName("pk_department_location");
 
-        builder.Property(dl => dl.Id).HasColumnName("id");
+        builder.Property(dl => dl.Id)
+            .HasColumnName("id")
+            .HasDefaultValueSql("gen_random_uuid()")
+            .ValueGeneratedOnAdd()
+            .HasSentinel(Guid.Empty);
         
         builder.Property(dl => dl.DepartmentId)
             .IsRequired()

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/EntityConfigurations/DepartmentPositionConfiguration.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/EntityConfigurations/DepartmentPositionConfiguration.cs
@@ -13,7 +13,11 @@ public class DepartmentPositionConfiguration: IEntityTypeConfiguration<Departmen
 
         builder.HasKey(dp => dp.Id).HasName("pk_department_position");
 
-        builder.Property(dp => dp.Id).HasColumnName("id");
+        builder.Property(dp => dp.Id)
+            .HasColumnName("id")
+            .HasDefaultValueSql("gen_random_uuid()")
+            .ValueGeneratedOnAdd()
+            .HasSentinel(Guid.Empty);
         
         builder.Property(dp => dp.DepartmentId)
             .IsRequired()

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Migrations/20260504120331_AddDefaultIdForJoinEntities.Designer.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Migrations/20260504120331_AddDefaultIdForJoinEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DirectoryService.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DirectoryService.Infrastructure.Migrations
 {
     [DbContext(typeof(DirectoryServiceDbContext))]
-    partial class DirectoryServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504120331_AddDefaultIdForJoinEntities")]
+    partial class AddDefaultIdForJoinEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Migrations/20260504120331_AddDefaultIdForJoinEntities.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Migrations/20260504120331_AddDefaultIdForJoinEntities.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DirectoryService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDefaultIdForJoinEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "department_position",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "gen_random_uuid()",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "department_location",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "gen_random_uuid()",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "department_position",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "gen_random_uuid()");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "department_location",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "gen_random_uuid()");
+        }
+    }
+}

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/DepartmentsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/DepartmentsRepository.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq.Expressions;
+using System.Reflection.Metadata;
 using CSharpFunctionalExtensions;
 using DirectoryService.Application.Departments.Interfaces;
+using DirectoryService.Domain.Common;
 using DirectoryService.Domain.Departments;
 using General.Errors;
 using Microsoft.EntityFrameworkCore;
@@ -19,15 +21,9 @@ public class DepartmentsRepository: IDepartmentsRepository
         _logger = logger;
     }
 
-    public async Task<Result<Guid, Failure>> AddAsync(Department department, CancellationToken cancellationToken)
+    public async Task<Guid> AddAsync(Department department, CancellationToken cancellationToken)
     {
         await _context.Departments.AddAsync(department, cancellationToken);
-
-        var result = await SaveAsync(cancellationToken);
-        if (result.IsFailure)
-            return result.Error;
-        
-        // _logger.LogInformation("Department {Id} created successfully", department.Id);
         return department.Id;
     }
 
@@ -51,20 +47,54 @@ public class DepartmentsRepository: IDepartmentsRepository
         int count = await _context.Departments.Where(expression).CountAsync(cancellationToken);
         return collection.Count == count;
     }
-    
-    public async Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken)
+
+    public async Task<UnitResult<Failure>> DeleteDepartmentLocationsByIdAsync(Guid departmentId, CancellationToken cancellationToken)
     {
         try
         {
-            await _context.SaveChangesAsync(cancellationToken);
+            await _context.DepartmentLocations.Where(dl => dl.DepartmentId == departmentId)
+                .ExecuteDeleteAsync(cancellationToken);
             return UnitResult.Success<Failure>();
         }
-        catch (Exception ex)
+        catch (Exception exception)
         {
-            _logger.LogError("Failed to save changes: {Error}", ex);
-            return UnitResult.Failure<Failure>(Failure.Error("Something went wrong", "server.internal"));
+            _logger.LogError(exception, "Failed to delete");
+            return UnitResult.Failure(CommonErrors.InternalError);
         }
     }
+
+    public async Task<Guid> AddDepartmentLocationsAsync(
+        Guid departmentId,
+        IEnumerable<Guid> locationIds,
+        CancellationToken cancellationToken)
+    {
+        var list = locationIds.Select(id => new DepartmentLocation(departmentId, id)).ToList();
+        await _context.DepartmentLocations.AddRangeAsync(list, cancellationToken);
+        return departmentId;
+    }
+    
+    public async Task<Guid> AddDepartmentLocationsAsync(
+        IEnumerable<DepartmentLocation> departmentLocations,
+        CancellationToken cancellationToken)
+    {
+        var list = departmentLocations.ToList();
+        await _context.DepartmentLocations.AddRangeAsync(list, cancellationToken);
+        return list.First().DepartmentId;
+    }
+    
+    // public async Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken)
+    // {
+    //     try
+    //     {
+    //         await _context.SaveChangesAsync(cancellationToken);
+    //         return UnitResult.Success<Failure>();
+    //     }
+    //     catch (Exception ex)
+    //     {
+    //         _logger.LogError("Failed to save changes: {Error}", ex);
+    //         return UnitResult.Failure<Failure>(CommonFailures.InternalError);
+    //     }
+    // }
     
     // public Task<Guid> DeleteAsync(Guid departmentId, CancellationToken cancellationToken) => throw new NotImplementedException();
 }

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/LocationsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/LocationsRepository.cs
@@ -20,15 +20,9 @@ public class LocationsRepository: ILocationsRepository
         _logger = logger;
     }
 
-    public async Task<Result<Guid, Failure>> AddAsync(Location location, CancellationToken cancellationToken)
+    public async Task<Guid> AddAsync(Location location, CancellationToken cancellationToken)
     {
       await _context.Locations.AddAsync(location, cancellationToken);
-      var result = await SaveAsync(cancellationToken);
-
-      if (result.IsFailure)
-          return result.Error;
-      
-      // _logger.LogInformation("Location {Id} created successfully", location.Id);
       return location.Id;
     }
 
@@ -54,19 +48,19 @@ public class LocationsRepository: ILocationsRepository
         return foundCount == collection.Count;
     }
 
-    public async Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken) 
-    {
-        try
-        {
-            await _context.SaveChangesAsync(cancellationToken);
-            return UnitResult.Success<Failure>();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to save changes: {Error}", ex);
-            return UnitResult.Failure(Failure.Error("Something went wrong", "server.internal"));
-        }
-    }
+    // public async Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken) 
+    // {
+    //     try
+    //     {
+    //         await _context.SaveChangesAsync(cancellationToken);
+    //         return UnitResult.Success<Failure>();
+    //     }
+    //     catch (Exception ex)
+    //     {
+    //         _logger.LogError("Failed to save changes: {Error}", ex);
+    //         return UnitResult.Failure(CommonFailures.InternalError);
+    //     }
+    // }
     
     // public Task<Guid> DeleteAsync(Guid locationId, CancellationToken cancellationToken) => throw new NotImplementedException();
     //

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/PositionsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/PositionsRepository.cs
@@ -21,16 +21,9 @@ public class PositionsRepository: IPositionsRepository
         _logger = logger;
     }
     
-    public async Task<Result<Guid, Failure>> AddAsync(Position position, CancellationToken cancellationToken)
+    public async Task<Guid> AddAsync(Position position, CancellationToken cancellationToken)
     {
         await _context.Positions.AddAsync(position, cancellationToken);
-
-        var saving = await SaveAsync(cancellationToken);
-
-        if (saving.IsFailure)
-            return saving.Error;
-
-        // _logger.LogInformation("Position {Id} created successfully", position.Id);
         return position.Id;
     }
 
@@ -56,17 +49,17 @@ public class PositionsRepository: IPositionsRepository
         return count == collection.Count;
     }
 
-    public async Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            await _context.SaveChangesAsync(cancellationToken);
-            return UnitResult.Success<Failure>();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to save changes: {Error}", ex);
-            return UnitResult.Failure(Failure.Error("Something went wrong", "server.internal"));
-        }
-    }
+    // public async Task<UnitResult<Failure>> SaveAsync(CancellationToken cancellationToken)
+    // {
+    //     try
+    //     {
+    //         await _context.SaveChangesAsync(cancellationToken);
+    //         return UnitResult.Success<Failure>();
+    //     }
+    //     catch (Exception ex)
+    //     {
+    //         _logger.LogError("Failed to save changes: {Error}", ex);
+    //         return UnitResult.Failure(CommonFailures.InternalError);
+    //     }
+    // }
 }

--- a/DirectoryService/src/DirectoryService.Presentation/Controllers/DepartmentsController.cs
+++ b/DirectoryService/src/DirectoryService.Presentation/Controllers/DepartmentsController.cs
@@ -16,4 +16,14 @@ public class DepartmentsController : ControllerBase
     {
         return await handler.Handle(new CreateDepartmentCommand(request), cancellationToken);
     }
+
+    [HttpPut("{departmentId:guid}/locations")]
+    public async Task<EndpointResult<Guid>> UpdateLocations(
+        [FromRoute] Guid departmentId,
+        [FromBody] UpdateDepartmentLocationsRequest request,
+        [FromServices] UpdateDepartmentLocationsHandler handler,
+        CancellationToken cancellationToken)
+    {
+        return await handler.Handle(new UpdateDepartmentLocationsCommand(departmentId, request), cancellationToken);
+    }
 }

--- a/DirectoryService/src/DirectoryService.Web/Configurations/WebDependencyInjection.cs
+++ b/DirectoryService/src/DirectoryService.Web/Configurations/WebDependencyInjection.cs
@@ -1,4 +1,5 @@
 ﻿using DirectoryService.Infrastructure.Configurations;
+using General.Converters;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
 using Serilog.Exceptions;
@@ -45,7 +46,11 @@ public static class WebDependencyInjection
 
     private static IServiceCollection AddControllersAndOpenApi(this IServiceCollection services)
     {
-        services.AddControllers();
+        services.AddControllers().AddJsonOptions(opt =>
+        {
+            // Регистрация Guid Converter
+            opt.JsonSerializerOptions.Converters.Add(new GuidJsonConverter());
+        });
         services.AddOpenApi();
 
         return services;

--- a/DirectoryService/src/DirectoryService.Web/Middleware/ExceptionMiddleware.cs
+++ b/DirectoryService/src/DirectoryService.Web/Middleware/ExceptionMiddleware.cs
@@ -1,4 +1,5 @@
-﻿using General;
+﻿using DirectoryService.Domain.Common;
+using General;
 using General.Errors;
 
 namespace DirectoryService.Web.Middleware;
@@ -24,7 +25,7 @@ public class ExceptionMiddleware
         {
             _logger.LogError(exception, "Unhandled exception with message: {Message}", exception.Message);
 
-            var envelope = Envelope.Error(Failure.Error("Something went wrong", "server.internal"));
+            var envelope = Envelope.Error(CommonErrors.InternalError);
             
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = StatusCodes.Status500InternalServerError;

--- a/DirectoryService/src/General/Converters/GuidJsonConverter.cs
+++ b/DirectoryService/src/General/Converters/GuidJsonConverter.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace General.Converters;
+
+public class GuidJsonConverter: JsonConverter<Guid>
+{
+    public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return Guid.TryParse(value, out var guid) ? guid : Guid.Empty;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}

--- a/DirectoryService/src/General/Errors/Failure.cs
+++ b/DirectoryService/src/General/Errors/Failure.cs
@@ -8,32 +8,36 @@ public record Failure
 {
     public string Code { get; }
     public string Message { get; }
-
-    private const char MAIN_SEPARATOR = '|';
-    private const char SECOND_SEPARATOR = ':';
+    
+    public Guid? EntityId { get; }
     
     public FailureType Type { get; }
     public string? InvalidField { get; }
     
-    private Failure(string code, string message, FailureType type, string? invalidField = null)
+    private const char MAIN_SEPARATOR = '|';
+    private const char SECOND_SEPARATOR = ':';
+    private Failure(string code, string message, FailureType type, string? invalidField = null, Guid? entityId = null)
     {
         Code = code;
         Message = message;
         Type = type;
         InvalidField = invalidField;
+        EntityId = entityId;
     }
 
     public static Failure Validation(string message, string? code = null, string? invalidField = null) =>
         new(code ?? "value.is.invalid", message, FailureType.VALIDATION, invalidField);
     
     public static Failure NotFoundEntity(string message, Guid? id, string? code = null) =>
-        new(code ?? "record.not.found", message, FailureType.NOT_FOUND);
+        new(code ?? "record.not.found", message, FailureType.NOT_FOUND, null, id);
     
     public static Failure NotFoundCollectionEntity(string message, string? code = null) =>
         new(code ?? "records.not.found", message, FailureType.NOT_FOUND);
     
     public static Failure Conflict(string message, string? code = null) => new(code ?? "value.conflict", message, FailureType.CONFLICT);
 
+    public static Failure ConflictEntity(string message, string? code = null, Guid? entityId = null) => new(code ?? "value.conflict", message, FailureType.CONFLICT, null, entityId);
+    
     public static Failure Error(string message, string? code = null) =>
         new(code ?? "error", message, FailureType.ERROR);
 
@@ -51,7 +55,7 @@ public record Failure
     public static Failure Deserialize(string failureString)
     {
         string[] rows = failureString.Split(MAIN_SEPARATOR);
-        if (rows.Length < 3)
+        if (rows.Length < 4)
             throw new FormatException($"Invalid failure string format: '{failureString}'");
 
         Dictionary<string, string> failDictionary = new();
@@ -62,7 +66,8 @@ public record Failure
             if (key != nameof(Code) &&
                 key != nameof(Message) &&
                 key != nameof(Type) &&
-                key != nameof(InvalidField))
+                key != nameof(InvalidField) &&
+                key != nameof(EntityId))
             {
                 throw new FormatException($"Unknown field '{key}' in failure string: '{failureString}'");
             }
@@ -73,8 +78,12 @@ public record Failure
         if(!Enum.TryParse<FailureType>(failDictionary[nameof(Type)], out FailureType type))
             throw new ArgumentException($"Unknown FailureType value: '{failDictionary[nameof(Type)]}'", paramName: nameof(failureString));
 
-        var fail = new Failure(failDictionary[nameof(Code)], failDictionary[nameof(Message)], type,
-            failDictionary[nameof(InvalidField)] == "null" ? null : failDictionary[nameof(InvalidField)]);
+        var fail = new Failure(
+            failDictionary[nameof(Code)], 
+            failDictionary[nameof(Message)],
+            type,
+            failDictionary[nameof(InvalidField)] == "null" ? null : failDictionary[nameof(InvalidField)],
+            failDictionary[nameof(EntityId)] == "null" ? null : Guid.Parse(failDictionary[nameof(EntityId)]));
         return fail;
     }
     
@@ -83,7 +92,8 @@ public record Failure
         string res = $@"{nameof(Code)} {SECOND_SEPARATOR} {failure.Code} {MAIN_SEPARATOR} 
                         {nameof(Message)} {SECOND_SEPARATOR} {failure.Message} {MAIN_SEPARATOR} 
                         {nameof(Type)} {SECOND_SEPARATOR} {failure.Type} {MAIN_SEPARATOR}
-                        {nameof(InvalidField)} {SECOND_SEPARATOR} {failure.InvalidField ?? "null"}";
+                        {nameof(InvalidField)} {SECOND_SEPARATOR} {failure.InvalidField ?? "null"} {MAIN_SEPARATOR}
+                        {nameof(EntityId)} {SECOND_SEPARATOR} {(failure.EntityId.HasValue ? failure.EntityId.ToString() : "null")}";
 
         return res;
     }


### PR DESCRIPTION
- Поправлено возвращение основных ошибок используемых при валидации в handlers, что бы не писать по сто раз руками
- Сначала ловил ошибку при обновлении через ChangeTracker. Дело в том что у меня Guid заполнялся в конструкторе DepartmentLocation и соответственно при получении Department и изменении коллекции, ChangeTracker думал что если Id уже есть то запись существует и дергал Update, вместо Insert. Не найдя Id он падал с ошибкой.
- До того как обошел ошибку, добавлял обновление через новый DbSet. Впоследствии оставил и этот способ просто как вариант.
- Поменял конфигурации Ef Core Entity для того что бы протестировать через ChangeTracker и сделал два конструктора для DepartmentLocation, так же сделал два метода у Department, на обновление и прописал в summary документацию метод, который принимает готовую коллекцию DepartmentLocation , что для обновления лучше дергать конструктор без явного указанного id.
- Так же хотел бы обратить внимание на TransactionScope, я сделал интерфейс ITransactionScope наследуемым не от IDisposable а от IAsyncDisposable, что бы асинхронно работать с транзакциями, надеюсь это ок.

Понимаю что сильно много нагородил, буду благодарен за фитбек, если что причешу код так что бы был только один вариант. 
