### PR TITLE
Интеграционные тесты

### DIFF
--- a/DirectoryService/.editorconfig
+++ b/DirectoryService/.editorconfig
@@ -242,6 +242,9 @@ tab_width = 4
 #CUSTOM
 
 #STYLE COP ANALYZERS
+
+dotnet_diagnostic.SA1202.severity = none
+dotnet_diagnostic.CA1815.serverity = none
 dotnet_diagnostic.CA1034.severity = none
 dotnet_diagnostic.CA1308.severity = none
 dotnet_diagnostic.CA1822.severity = none

--- a/DirectoryService/.editorconfig
+++ b/DirectoryService/.editorconfig
@@ -244,7 +244,7 @@ tab_width = 4
 #STYLE COP ANALYZERS
 
 dotnet_diagnostic.SA1202.severity = none
-dotnet_diagnostic.CA1815.serverity = none
+dotnet_diagnostic.CA1815.severity = none
 dotnet_diagnostic.CA1034.severity = none
 dotnet_diagnostic.CA1308.severity = none
 dotnet_diagnostic.CA1822.severity = none

--- a/DirectoryService/DirectoryService.sln
+++ b/DirectoryService/DirectoryService.sln
@@ -22,6 +22,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DirectoryService.Contracts"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "General", "src\General\General.csproj", "{272F7A9D-FF96-4F3D-85A5-4F78DE4A7453}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A043C67F-EE78-43FB-AB7F-72654AA5EDDD}"
+	ProjectSection(SolutionItems) = preProject
+		src\tests\xunit.runner.json = src\tests\xunit.runner.json
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DirectoryService.IntegrationTests", "src\tests\DirectoryService.IntegrationTests\DirectoryService.IntegrationTests.csproj", "{D7E693A8-61D7-4418-809E-6663C8DAB41D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DirectoryService.TestData", "src\DirectoryService.TestData\DirectoryService.TestData.csproj", "{48C6F6C8-6A62-4752-A093-6D44F582F1A9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +65,14 @@ Global
 		{272F7A9D-FF96-4F3D-85A5-4F78DE4A7453}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{272F7A9D-FF96-4F3D-85A5-4F78DE4A7453}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{272F7A9D-FF96-4F3D-85A5-4F78DE4A7453}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7E693A8-61D7-4418-809E-6663C8DAB41D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7E693A8-61D7-4418-809E-6663C8DAB41D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7E693A8-61D7-4418-809E-6663C8DAB41D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7E693A8-61D7-4418-809E-6663C8DAB41D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48C6F6C8-6A62-4752-A093-6D44F582F1A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48C6F6C8-6A62-4752-A093-6D44F582F1A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48C6F6C8-6A62-4752-A093-6D44F582F1A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48C6F6C8-6A62-4752-A093-6D44F582F1A9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{912517BB-0269-4EC1-BA50-3B6E9A3983F0} = {5C67ADBF-6DDB-49AE-B14A-614138DA1FB9}
@@ -65,5 +82,8 @@ Global
 		{2366C1EA-80CE-4AB1-9993-C39D2A5F36C6} = {5C67ADBF-6DDB-49AE-B14A-614138DA1FB9}
 		{F8C5CD9C-D5D0-4FA6-A374-E50CB7EF0311} = {5C67ADBF-6DDB-49AE-B14A-614138DA1FB9}
 		{272F7A9D-FF96-4F3D-85A5-4F78DE4A7453} = {5C67ADBF-6DDB-49AE-B14A-614138DA1FB9}
+		{A043C67F-EE78-43FB-AB7F-72654AA5EDDD} = {5C67ADBF-6DDB-49AE-B14A-614138DA1FB9}
+		{D7E693A8-61D7-4418-809E-6663C8DAB41D} = {A043C67F-EE78-43FB-AB7F-72654AA5EDDD}
+		{48C6F6C8-6A62-4752-A093-6D44F582F1A9} = {5C67ADBF-6DDB-49AE-B14A-614138DA1FB9}
 	EndGlobalSection
 EndGlobal

--- a/DirectoryService/src/DirectoryService.Application/Departments/Interfaces/IDepartmentsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/Interfaces/IDepartmentsRepository.cs
@@ -19,7 +19,7 @@ public interface IDepartmentsRepository
     
     Task<bool> AllMatchAsync(IEnumerable<Guid> ids, Expression<Func<Department, bool>> expression,
         CancellationToken cancellationToken);
-    Task<bool> IsDescendantOfAsync(string childPath, string parentPath, CancellationToken cancellationToken);
+    Task<bool> IsDescendantOfAsync(string potentialDescendantPath, string ancestorPath, CancellationToken cancellationToken);
 
     Task<UnitResult<Failure>> DeleteDepartmentLocationsByIdAsync(Guid departmentId, CancellationToken cancellationToken);
 

--- a/DirectoryService/src/DirectoryService.Application/Departments/MoveDepartmentHandler.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/MoveDepartmentHandler.cs
@@ -67,11 +67,11 @@ public class MoveDepartmentHandler : ICommandHandler<Guid, MoveDepartmentCommand
 
         if (parent is not null && department is not null)
         {
-            bool checkPath =
-                await _departmentsRepository.IsDescendantOfAsync(department.Path.Value, parent.Path.Value,
+            bool isDescendant =
+                await _departmentsRepository.IsDescendantOfAsync(parent.Path.Value, department.Path.Value,
                     cancellationToken);
             
-            if (checkPath)
+            if (isDescendant)
             {
                 return Failure
                     .Conflict("A descendant department cannot be set as a parent", "department.path.conflict")

--- a/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsCommand.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsCommand.cs
@@ -3,4 +3,4 @@ using DirectoryService.Contracts.Departments;
 
 namespace DirectoryService.Application.Departments;
 
-public record UpdateDepartmentLocationsCommand(Guid DepartmentId, UpdateDepartmentLocationsRequest Request) : ICommand;
+public record UpdateDepartmentLocationsCommand(Guid DepartmentId, IReadOnlyList<Guid> LocationIds) : ICommand;

--- a/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsHandler.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsHandler.cs
@@ -18,14 +18,14 @@ public class UpdateDepartmentLocationsHandler : ICommandHandler<Guid, UpdateDepa
     private readonly IDepartmentsRepository _departmentsRepository;
     private readonly ILocationsRepository _locationsRepository;
     private readonly ITransactionManager _transactionManager;
-    private readonly IValidator<UpdateDepartmentLocationsRequest> _validator;
+    private readonly IValidator<UpdateDepartmentLocationsCommand> _validator;
     private readonly ILogger<UpdateDepartmentLocationsHandler> _logger;
 
     public UpdateDepartmentLocationsHandler(
         IDepartmentsRepository departmentsRepository,
         ILocationsRepository locationsRepository,
         ITransactionManager transactionManager,
-        IValidator<UpdateDepartmentLocationsRequest> validator,
+        IValidator<UpdateDepartmentLocationsCommand> validator,
         ILogger<UpdateDepartmentLocationsHandler> logger)
     {
         _departmentsRepository = departmentsRepository;
@@ -40,7 +40,7 @@ public class UpdateDepartmentLocationsHandler : ICommandHandler<Guid, UpdateDepa
         CancellationToken cancellationToken)
     {
         // Валидация входных параметров
-        var validationResult = await _validator.ValidateAsync(command.Request, cancellationToken);
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
 
         if (!validationResult.IsValid)
             return validationResult.ToFailList();
@@ -54,12 +54,12 @@ public class UpdateDepartmentLocationsHandler : ICommandHandler<Guid, UpdateDepa
 
         // Бизнес валидация
         bool allLocationsExist = await _locationsRepository.AllMatchAsync(
-            command.Request.LocationIds,
-            l => command.Request.LocationIds.Contains(l.Id), 
+            command.LocationIds,
+            l => command.LocationIds.Contains(l.Id), 
             cancellationToken);
 
         if (!allLocationsExist)
-            return LocationErrors.CollectionNotFound(command.Request.LocationIds).ToFailList();
+            return LocationErrors.CollectionNotFound(command.LocationIds).ToFailList();
 
         Department? department = await 
             _departmentsRepository.GetByAsync(d => d.Id == command.DepartmentId, cancellationToken);
@@ -77,7 +77,7 @@ public class UpdateDepartmentLocationsHandler : ICommandHandler<Guid, UpdateDepa
             return delete.Error.ToFailList();
         }
 
-        department.UpdateLocations(command.Request.LocationIds);
+        department.UpdateLocations(command.LocationIds);
         
         var saveChanges = await _transactionManager.SaveChangesAsync(cancellationToken);
 

--- a/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsValidator.cs
+++ b/DirectoryService/src/DirectoryService.Application/Departments/UpdateDepartmentLocationsValidator.cs
@@ -1,22 +1,26 @@
 ﻿using DirectoryService.Application.Validation;
 using DirectoryService.Contracts.Departments;
 using DirectoryService.Domain.Common;
+using DirectoryService.Domain.Common.DomainEntityErrors;
 using FluentValidation;
 using General.Errors;
 
 namespace DirectoryService.Application.Departments;
 
-public class UpdateDepartmentLocationsValidator: AbstractValidator<UpdateDepartmentLocationsRequest>
+public class UpdateDepartmentLocationsValidator: AbstractValidator<UpdateDepartmentLocationsCommand>
 {
     public UpdateDepartmentLocationsValidator()
     {
-        RuleFor(r => r).NotNull().WithError(Failure.Error(
+        RuleFor(c => c).NotNull().WithError(Failure.Error(
                                                           "Invalid Request", "request.invalid"));
-
-        RuleForEach(r => r.LocationIds).NotEqual(Guid.Empty)
+        
+        RuleFor(c => c.DepartmentId).NotEqual(Guid.Empty)
+            .WithError(Failure.Validation("The Department ID must not be empty.", "department-id.invalid"));
+        
+        RuleForEach(c => c.LocationIds).NotEqual(Guid.Empty)
             .WithError(CommonErrors.CollectionItemsInvalid("Location-id"));
         
-        RuleFor(r => r.LocationIds)
+        RuleFor(c => c.LocationIds)
             .NotEmpty()
             .WithError(CommonErrors.CollectionEmpty("location-id"))
             .AllUnique()

--- a/DirectoryService/src/DirectoryService.Domain/Common/Constants/LengthConstants.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Common/Constants/LengthConstants.cs
@@ -8,5 +8,6 @@ public readonly struct LengthConstants
     public const int MAX_LENGTH_100 = 100;
     public const int MAX_LENGTH_1000 = 1000;
     public const int MIN_LENGTH_3 = 3;
+    public const int MIN_LENGTH_2 = 2;
 }
 #pragma warning restore CA1815

--- a/DirectoryService/src/DirectoryService.Domain/Locations/Location.cs
+++ b/DirectoryService/src/DirectoryService.Domain/Locations/Location.cs
@@ -36,12 +36,10 @@ public class Location
     {
     }
 
-    public static Result<Location, Failure> Create(LocationName locationName, Address address, Timezone timezone)
+    public static Result<Location, Failure> Create(LocationName locationName, Address address, Timezone timezone, Guid? id = null)
     {
-        Guid id = Guid.NewGuid();
         var now = DateTime.UtcNow;
-
-        return new Location(id, locationName, address, timezone, true, now, now);
+        return new Location(id ?? Guid.NewGuid(), locationName, address, timezone, true, now, now);
     }
 
     public void AddDepartments(params Guid[] departmentIds)

--- a/DirectoryService/src/DirectoryService.Domain/ValueObjects/Address.cs
+++ b/DirectoryService/src/DirectoryService.Domain/ValueObjects/Address.cs
@@ -34,7 +34,7 @@ public record Address
     public static Result<Address, Failure> Create(string country, string city, string street, string houseNumber,
         int postalCode)
     {
-        string houseNumberRegex = @"^[A-Za-z0-9/\-\.]+$";
+        string houseNumberRegex = @"^[A-Za-z0-9\u0400-\u04FF/\-\.]+$";
         bool notEmptyInvalidHouseNumber = false;
         bool invalidPostalCode = false;
         List<string> fields = [];

--- a/DirectoryService/src/DirectoryService.Domain/ValueObjects/Identifier.cs
+++ b/DirectoryService/src/DirectoryService.Domain/ValueObjects/Identifier.cs
@@ -1,4 +1,5 @@
-﻿using CSharpFunctionalExtensions;
+﻿using System.Globalization;
+using CSharpFunctionalExtensions;
 using DirectoryService.Domain.Common;
 using DirectoryService.Domain.Common.Constants;
 using General;
@@ -9,13 +10,13 @@ namespace DirectoryService.Domain.ValueObjects;
 public record Identifier
 {
     public const int MAX_LENGTH = LengthConstants.MAX_LENGTH_150;
-    public const int MIN_LENGTH = LengthConstants.MIN_LENGTH_3;
+    public const int MIN_LENGTH = LengthConstants.MIN_LENGTH_2;
     private const char SEPARATOR = '-';
     public string Value { get; }
 
     private Identifier(string value)
     {
-        Value = value;
+        Value = value.ToLower(CultureInfo.InvariantCulture);
     }
 
     public static Result<Identifier, Failure> Create(string value)

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Configurations/InfrastructureDependencyInjection.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Configurations/InfrastructureDependencyInjection.cs
@@ -6,6 +6,7 @@ using DirectoryService.Application.Positions.Interfaces;
 using DirectoryService.Domain.Common.Constants;
 using DirectoryService.Infrastructure.Database;
 using DirectoryService.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,20 +21,24 @@ public static class InfrastructureDependencyInjection
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        return services.UseCaseRegistration().DbContextRegistration(configuration).AddRepositories();
+        return services.UseCaseRegistration()
+            .DbContextRegistration()
+            .AddRepositories()
+            .AddTransactionTools();
     }
     
-    private static IServiceCollection DbContextRegistration(this IServiceCollection services, IConfiguration configuration)
+    private static IServiceCollection DbContextRegistration(this IServiceCollection services)
     {
         services.AddDbContextPool<DirectoryServiceDbContext>((sp, options) =>
         {
+            IConfiguration configuration = sp.GetRequiredService<IConfiguration>();
             string? connectionString = configuration.GetConnectionString(DatabaseConstants.DATABASE);
             IHostEnvironment hostEnv = sp.GetRequiredService<IHostEnvironment>();
             ILoggerFactory loggerFactory = sp.GetRequiredService<ILoggerFactory>();
 
             options.UseNpgsql(connectionString);
 
-            if (hostEnv.IsDevelopment())
+            if (hostEnv.IsDevelopment() || hostEnv.IsEnvironment("Testing"))
             {
                 options.EnableSensitiveDataLogging();
                 options.EnableDetailedErrors();
@@ -41,11 +46,14 @@ public static class InfrastructureDependencyInjection
 
             options.UseLoggerFactory(loggerFactory);
         });
-
-        services.AddSingleton<IDbConnectionFactory, NpgSqlConnectionFactory>();
-
-        services.AddScoped<ITransactionManager, TransactionManager>();
         
+        return services;
+    }
+
+    private static IServiceCollection AddTransactionTools(this IServiceCollection services)
+    {
+        services.AddSingleton<IDbConnectionFactory, NpgSqlConnectionFactory>();
+        services.AddScoped<ITransactionManager, TransactionManager>();
         return services;
     }
     

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Database/IDataSeeder.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Database/IDataSeeder.cs
@@ -1,0 +1,6 @@
+﻿namespace DirectoryService.Infrastructure.Database;
+
+public interface IDataSeeder
+{
+    Task SeedAsync();
+}

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/EntityConfigurations/LocationConfiguration.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/EntityConfigurations/LocationConfiguration.cs
@@ -25,9 +25,19 @@ public class LocationConfiguration: IEntityTypeConfiguration<Location>
             .IsUnique()
             .HasDatabaseName("ux_locations_name");
 
+        // builder.OwnsOne(l => l.Address, lb =>
+        // {
+        //     lb.ToJson("address").HasColumnType("jsonb");
+        //
+        //     lb.Property(a => a.Country).HasJsonPropertyName("country");
+        //     lb.Property(a => a.City).HasJsonPropertyName("city");
+        //     lb.Property(a => a.Street).HasJsonPropertyName("street");
+        //     lb.Property(a => a.HouseNumber).HasJsonPropertyName("house_number");
+        //     lb.Property(a => a.PostalCode).HasJsonPropertyName("postal_code");
+        // });
         builder.OwnsOne(l => l.Address, lb =>
         {
-            lb.ToJson("address").HasColumnType("jsonb");
+            lb.ToJson("address");
 
             lb.Property(a => a.Country).HasJsonPropertyName("country");
             lb.Property(a => a.City).HasJsonPropertyName("city");

--- a/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/DepartmentsRepository.cs
+++ b/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Repositories/DepartmentsRepository.cs
@@ -78,12 +78,20 @@ public class DepartmentsRepository: IDepartmentsRepository
         return collection.Count == count;
     }
 
-    public async Task<bool> IsDescendantOfAsync(string childPath, string parentPath,
-        CancellationToken cancellationToken)
+    public async Task<bool> IsDescendantOfAsync(string potentialDescendantPath, string ancestorPath, CancellationToken cancellationToken)
     {
-        var count = await _context.Database
-            .ExecuteSqlRawAsync("""SELECT COUNT(*) FROM departments WHERE {0}::ltree <@ {1}::ltree AND {0}::ltree != {1}::ltree """, childPath, parentPath);
-        return count > 0;
+        var connection = _context.Database.GetDbConnection();
+        
+        string query =
+            """ SELECT EXISTS(SELECT 1 FROM departments WHERE  @descendant::ltree <@ @ancestor::ltree AND  @descendant::ltree != @ancestor::ltree) """;
+       
+        var param = new { descendant = potentialDescendantPath, ancestor = ancestorPath };
+        
+        var queryCommand = new CommandDefinition(query, param, cancellationToken: cancellationToken);
+        
+        var result = await connection.ExecuteScalarAsync<bool>(queryCommand);
+
+        return result;
     }
     
     public async Task<UnitResult<Failure>> DeleteDepartmentLocationsByIdAsync(Guid departmentId, CancellationToken cancellationToken)

--- a/DirectoryService/src/DirectoryService.Presentation/Controllers/DepartmentsController.cs
+++ b/DirectoryService/src/DirectoryService.Presentation/Controllers/DepartmentsController.cs
@@ -24,7 +24,7 @@ public class DepartmentsController : ControllerBase
         [FromServices] UpdateDepartmentLocationsHandler handler,
         CancellationToken cancellationToken)
     {
-        return await handler.Handle(new UpdateDepartmentLocationsCommand(departmentId, request), cancellationToken);
+        return await handler.Handle(new UpdateDepartmentLocationsCommand(departmentId, request.LocationIds), cancellationToken);
     }
 
     [HttpPut("{departmentId:guid}/parent")]

--- a/DirectoryService/src/DirectoryService.TestData/DataSeeder.cs
+++ b/DirectoryService/src/DirectoryService.TestData/DataSeeder.cs
@@ -1,0 +1,28 @@
+﻿using DirectoryService.Infrastructure;
+using DirectoryService.Infrastructure.Database;
+using DirectoryService.TestData.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace DirectoryService.TestData;
+
+public class DataSeeder: IDataSeeder
+{
+    private readonly DirectoryServiceDbContext _dbContext;
+
+    public DataSeeder(DirectoryServiceDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task SeedAsync()
+    {
+        if (await _dbContext.Locations.AnyAsync()) return;
+
+        await _dbContext.Locations.AddRangeAsync(LocationFixtures.All);
+        await _dbContext.Departments.AddRangeAsync(DepartmentFixtures.All);
+        await _dbContext.Positions.AddRangeAsync(PositionFixtures.All);
+    
+        await _dbContext.SaveChangesAsync();
+    }
+
+}

--- a/DirectoryService/src/DirectoryService.TestData/DirectoryService.TestData.csproj
+++ b/DirectoryService/src/DirectoryService.TestData/DirectoryService.TestData.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\DirectoryService.Infrastructure.Postgres\DirectoryService.Infrastructure.Postgres.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/DirectoryService/src/DirectoryService.TestData/Fixtures/DepartmentFixtures.cs
+++ b/DirectoryService/src/DirectoryService.TestData/Fixtures/DepartmentFixtures.cs
@@ -1,0 +1,106 @@
+﻿using DirectoryService.Domain.Departments;
+using DirectoryService.Domain.ValueObjects;
+using DirectoryService.TestData.Fixtures;
+
+namespace DirectoryService.TestData.Fixtures;
+
+public static class DepartmentFixtures
+{
+    public static readonly Guid ItId = Guid.Parse("00000000-0000-0000-0001-000000000001");
+    public static readonly Guid SoftwareDevId = Guid.Parse("00000000-0000-0000-0001-000000000002");
+    public static readonly Guid InfraDevOpsId = Guid.Parse("00000000-0000-0000-0001-000000000003");
+    public static readonly Guid HrId = Guid.Parse("00000000-0000-0000-0001-000000000004");
+    public static readonly Guid RecruitingId = Guid.Parse("00000000-0000-0000-0001-000000000005");
+    public static readonly Guid FinanceId = Guid.Parse("00000000-0000-0000-0001-000000000006");
+    public static readonly Guid AccountingId = Guid.Parse("00000000-0000-0000-0001-000000000007");
+    public static readonly Guid SalesId = Guid.Parse("00000000-0000-0000-0001-000000000008");
+    public static readonly Guid MarketingId = Guid.Parse("00000000-0000-0000-0001-000000000009");
+    public static readonly Guid LegalId = Guid.Parse("00000000-0000-0000-0001-000000000010");
+
+    public static readonly Department IT = Department.CreateParent(
+        DepartmentName.Convert("Information Technology"),
+        Identifier.Convert("IT"),
+        [new DepartmentLocation(ItId, LocationFixtures.BerlinId)],
+        ItId).Value;
+
+    public static readonly Department SoftwareDev = Department.CreateChild(
+        DepartmentName.Convert("Software Development"),
+        Identifier.Convert("IT-DEV"),
+        IT,
+        [
+            new DepartmentLocation(SoftwareDevId, LocationFixtures.BerlinId),
+            new DepartmentLocation(SoftwareDevId, LocationFixtures.MunichId)
+        ],
+        SoftwareDevId).Value;
+
+    public static readonly Department InfraDevOps = Department.CreateChild(
+        DepartmentName.Convert("Infrastructure & DevOps"),
+        Identifier.Convert("IT-OPS"),
+        SoftwareDev,
+        [new DepartmentLocation(InfraDevOpsId, LocationFixtures.BerlinId)],
+        InfraDevOpsId).Value;
+
+    public static readonly Department HR = Department.CreateParent(
+        DepartmentName.Convert("Human Resources"),
+        Identifier.Convert("HR"),
+        [
+            new DepartmentLocation(HrId, LocationFixtures.BerlinId),
+            new DepartmentLocation(HrId, LocationFixtures.HamburgId)
+        ],
+        HrId).Value;
+
+    public static readonly Department Recruiting = Department.CreateChild(
+        DepartmentName.Convert("Recruiting"),
+        Identifier.Convert("HR-REC"),
+        HR,
+        [new DepartmentLocation(RecruitingId, LocationFixtures.BerlinId)],
+        RecruitingId).Value;
+
+    public static readonly Department Finance = Department.CreateParent(
+        DepartmentName.Convert("Finance"),
+        Identifier.Convert("FIN"),
+        [new DepartmentLocation(FinanceId, LocationFixtures.FrankfurtId)],
+        FinanceId).Value;
+
+    public static readonly Department Accounting = Department.CreateChild(
+        DepartmentName.Convert("Accounting"),
+        Identifier.Convert("FIN-ACC"),
+        Finance,
+        [new DepartmentLocation(AccountingId, LocationFixtures.FrankfurtId)],
+        AccountingId).Value;
+
+    public static readonly Department Sales = Department.CreateParent(
+        DepartmentName.Convert("Sales"),
+        Identifier.Convert("SALES"),
+        [
+            new DepartmentLocation(SalesId, LocationFixtures.MunichId),
+            new DepartmentLocation(SalesId, LocationFixtures.CologneId)
+        ],
+        SalesId).Value;
+
+    public static readonly Department Marketing = Department.CreateParent(
+        DepartmentName.Convert("Marketing"),
+        Identifier.Convert("MKT"),
+        [
+            new DepartmentLocation(MarketingId, LocationFixtures.BerlinId),
+            new DepartmentLocation(MarketingId, LocationFixtures.AmsterdamId)
+        ],
+        MarketingId).Value;
+
+    public static readonly Department Legal = Department.CreateParent(
+        DepartmentName.Convert("Legal"),
+        Identifier.Convert("LEG"),
+        [
+            new DepartmentLocation(LegalId, LocationFixtures.BerlinId),
+            new DepartmentLocation(LegalId, LocationFixtures.ViennaId)
+        ],
+        LegalId).Value;
+
+    public static IReadOnlyList<Department> All =>
+    [
+        IT, SoftwareDev, InfraDevOps,
+        HR, Recruiting,
+        Finance, Accounting,
+        Sales, Marketing, Legal
+    ];
+}

--- a/DirectoryService/src/DirectoryService.TestData/Fixtures/LocationFixtures.cs
+++ b/DirectoryService/src/DirectoryService.TestData/Fixtures/LocationFixtures.cs
@@ -1,0 +1,84 @@
+﻿using DirectoryService.Domain.Locations;
+using DirectoryService.Domain.ValueObjects;
+
+namespace DirectoryService.TestData.Fixtures;
+
+public static class LocationFixtures
+{
+    public static readonly Guid BerlinId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    public static readonly Guid MunichId = Guid.Parse("00000000-0000-0000-0000-000000000002");
+    public static readonly Guid HamburgId = Guid.Parse("00000000-0000-0000-0000-000000000003");
+    public static readonly Guid FrankfurtId = Guid.Parse("00000000-0000-0000-0000-000000000004");
+    public static readonly Guid CologneId = Guid.Parse("00000000-0000-0000-0000-000000000005");
+    public static readonly Guid WarsawId = Guid.Parse("00000000-0000-0000-0000-000000000006");
+    public static readonly Guid ViennaId = Guid.Parse("00000000-0000-0000-0000-000000000007");
+    public static readonly Guid ZurichId = Guid.Parse("00000000-0000-0000-0000-000000000008");
+    public static readonly Guid AmsterdamId = Guid.Parse("00000000-0000-0000-0000-000000000009");
+    public static readonly Guid PragueId = Guid.Parse("00000000-0000-0000-0000-000000000010");
+
+    public static readonly Location Berlin = Location.Create(
+        LocationName.Convert("Berlin Main"),
+        Address.Convert("Germany", "Berlin", "Unter den Linden", "12", 10117),
+        Timezone.Convert("Europe/Berlin"),
+        BerlinId).Value;
+
+    public static readonly Location Munich = Location.Create(
+        LocationName.Convert("Munich Office"),
+        Address.Convert("Germany", "Munich", "Maximilianstrasse", "5", 80539),
+        Timezone.Convert("Europe/Berlin"),
+        MunichId).Value;
+
+    public static readonly Location Hamburg = Location.Create(
+        LocationName.Convert("Hamburg Office"),
+        Address.Convert("Germany", "Hamburg", "Moenckebergstrasse", "21", 20095),
+        Timezone.Convert("Europe/Berlin"),
+        HamburgId).Value;
+
+    public static readonly Location Frankfurt = Location.Create(
+        LocationName.Convert("Frankfurt Office"),
+        Address.Convert("Germany", "Frankfurt", "Kaiserstrasse", "8", 60311),
+        Timezone.Convert("Europe/Berlin"),
+        FrankfurtId).Value;
+
+    public static readonly Location Cologne = Location.Create(
+        LocationName.Convert("Cologne Office"),
+        Address.Convert("Germany", "Cologne", "Schildergasse", "3", 50667),
+        Timezone.Convert("Europe/Berlin"),
+        CologneId).Value;
+
+    public static readonly Location Warsaw = Location.Create(
+        LocationName.Convert("Warsaw Office"),
+        Address.Convert("Poland", "Warsaw", "Nowy Swiat", "15", 10000),
+        Timezone.Convert("Europe/Warsaw"),
+        WarsawId).Value;
+
+    public static readonly Location Vienna = Location.Create(
+        LocationName.Convert("Vienna Office"),
+        Address.Convert("Austria", "Vienna", "Kaerntner Strasse", "9", 1010),
+        Timezone.Convert("Europe/Vienna"),
+        ViennaId).Value;
+
+    public static readonly Location Zurich = Location.Create(
+        LocationName.Convert("Zurich Office"),
+        Address.Convert("Switzerland", "Zurich", "Bahnhofstrasse", "33", 8001),
+        Timezone.Convert("Europe/Zurich"),
+        ZurichId).Value;
+
+    public static readonly Location Amsterdam = Location.Create(
+        LocationName.Convert("Amsterdam Office"),
+        Address.Convert("Netherlands", "Amsterdam", "Damrak", "70", 1012),
+        Timezone.Convert("Europe/Amsterdam"),
+        AmsterdamId).Value;
+
+    public static readonly Location Prague = Location.Create(
+        LocationName.Convert("Prague Office"),
+        Address.Convert("Czech Republic", "Prague", "Vaclavske namesti", "11", 11000),
+        Timezone.Convert("Europe/Prague"),
+        PragueId).Value;
+
+    public static IReadOnlyList<Location> All =>
+    [
+        Berlin, Munich, Hamburg, Frankfurt, Cologne,
+        Warsaw, Vienna, Zurich, Amsterdam, Prague
+    ];
+}

--- a/DirectoryService/src/DirectoryService.TestData/Fixtures/PositionFixtures.cs
+++ b/DirectoryService/src/DirectoryService.TestData/Fixtures/PositionFixtures.cs
@@ -1,0 +1,87 @@
+﻿using DirectoryService.Domain.Departments;
+using DirectoryService.Domain.Positions;
+using DirectoryService.Domain.ValueObjects;
+
+namespace DirectoryService.TestData.Fixtures;
+
+public static class PositionFixtures
+{
+    public static readonly Guid ItDirectorId = Guid.Parse("00000000-0000-0000-0002-000000000001");
+    public static readonly Guid SoftwareEngineerId = Guid.Parse("00000000-0000-0000-0002-000000000002");
+    public static readonly Guid DevOpsEngineerId = Guid.Parse("00000000-0000-0000-0002-000000000003");
+    public static readonly Guid HrManagerId = Guid.Parse("00000000-0000-0000-0002-000000000004");
+    public static readonly Guid RecruiterId = Guid.Parse("00000000-0000-0000-0002-000000000005");
+    public static readonly Guid CfoId = Guid.Parse("00000000-0000-0000-0002-000000000006");
+    public static readonly Guid AccountantId = Guid.Parse("00000000-0000-0000-0002-000000000007");
+    public static readonly Guid SalesManagerId = Guid.Parse("00000000-0000-0000-0002-000000000008");
+    public static readonly Guid MarketingSpecialistId = Guid.Parse("00000000-0000-0000-0002-000000000009");
+    public static readonly Guid LegalCounselId = Guid.Parse("00000000-0000-0000-0002-000000000010");
+
+    public static readonly Position ItDirector = Position.Create(
+        PositionName.Convert("IT Director"),
+        [new DepartmentPosition(DepartmentFixtures.ItId, ItDirectorId)],
+        "Oversees all IT operations and strategy.",
+        ItDirectorId).Value;
+
+    public static readonly Position SoftwareEngineer = Position.Create(
+        PositionName.Convert("Software Engineer"),
+        [new DepartmentPosition(DepartmentFixtures.SoftwareDevId, SoftwareEngineerId)],
+        "Designs and develops software systems.",
+        SoftwareEngineerId).Value;
+
+    public static readonly Position DevOpsEngineer = Position.Create(
+        PositionName.Convert("DevOps Engineer"),
+        [new DepartmentPosition(DepartmentFixtures.InfraDevOpsId, DevOpsEngineerId)],
+        "Manages CI/CD pipelines and cloud infra.",
+        DevOpsEngineerId).Value;
+
+    public static readonly Position HrManager = Position.Create(
+        PositionName.Convert("HR Manager"),
+        [new DepartmentPosition(DepartmentFixtures.HrId, HrManagerId)],
+        "Leads HR operations and employee relations.",
+        HrManagerId).Value;
+
+    public static readonly Position Recruiter = Position.Create(
+        PositionName.Convert("Recruiter"),
+        [new DepartmentPosition(DepartmentFixtures.RecruitingId, RecruiterId)],
+        "Sources and coordinates candidate hiring.",
+        RecruiterId).Value;
+
+    public static readonly Position Cfo = Position.Create(
+        PositionName.Convert("CFO"),
+        [new DepartmentPosition(DepartmentFixtures.FinanceId, CfoId)],
+        "Responsible for financial planning.",
+        CfoId).Value;
+
+    public static readonly Position Accountant = Position.Create(
+        PositionName.Convert("Accountant"),
+        [new DepartmentPosition(DepartmentFixtures.AccountingId, AccountantId)],
+        "Handles bookkeeping and financial reports.",
+        AccountantId).Value;
+
+    public static readonly Position SalesManager = Position.Create(
+        PositionName.Convert("Sales Manager"),
+        [new DepartmentPosition(DepartmentFixtures.SalesId, SalesManagerId)],
+        "Drives revenue growth and leads sales team.",
+        SalesManagerId).Value;
+
+    public static readonly Position MarketingSpecialist = Position.Create(
+        PositionName.Convert("Marketing Specialist"),
+        [new DepartmentPosition(DepartmentFixtures.MarketingId, MarketingSpecialistId)],
+        "Plans and executes marketing campaigns.",
+        MarketingSpecialistId).Value;
+
+    public static readonly Position LegalCounsel = Position.Create(
+        PositionName.Convert("Legal Counsel"),
+        [new DepartmentPosition(DepartmentFixtures.LegalId, LegalCounselId)],
+        "Advises on contracts and compliance.",
+        LegalCounselId).Value;
+
+    public static IReadOnlyList<Position> All =>
+    [
+        ItDirector, SoftwareEngineer, DevOpsEngineer,
+        HrManager, Recruiter,
+        Cfo, Accountant,
+        SalesManager, MarketingSpecialist, LegalCounsel
+    ];
+}

--- a/DirectoryService/src/DirectoryService.Web/Configurations/WebDependencyInjection.cs
+++ b/DirectoryService/src/DirectoryService.Web/Configurations/WebDependencyInjection.cs
@@ -1,4 +1,6 @@
 ﻿using DirectoryService.Infrastructure.Configurations;
+using DirectoryService.Infrastructure.Database;
+using DirectoryService.TestData;
 using General.Converters;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
@@ -14,7 +16,8 @@ public static class WebDependencyInjection
             .AddLogger(configuration)
             .AddInfrastructurePostgres(configuration)
             .AddControllersAndOpenApi()
-            .ConfigureApiBehaviorOptions();
+            .ConfigureApiBehaviorOptions()
+            .AddSeeder();
 
     }
     
@@ -64,5 +67,25 @@ public static class WebDependencyInjection
         });
 
         return services;
+    }
+
+    private static IServiceCollection AddSeeder(this IServiceCollection services)
+    { 
+#if  DEBUG
+        services.AddScoped<IDataSeeder, DataSeeder>();  
+#endif
+        return services;
+    }
+
+    public static async Task<WebApplication> RunSeedAsync(this WebApplication app)
+    {
+        if (!app.Environment.IsDevelopment())
+            return app;
+#if DEBUG
+        await using var scope = app.Services.CreateAsyncScope();
+        var seeder = scope.ServiceProvider.GetRequiredService<IDataSeeder>();
+        await seeder.SeedAsync();
+#endif
+        return app;
     }
 }

--- a/DirectoryService/src/DirectoryService.Web/DirectoryService.Web.csproj
+++ b/DirectoryService/src/DirectoryService.Web/DirectoryService.Web.csproj
@@ -34,5 +34,9 @@
     <ProjectReference Include="..\DirectoryService.Infrastructure.Postgres\DirectoryService.Infrastructure.Postgres.csproj" />
     <ProjectReference Include="..\DirectoryService.Presentation\DirectoryService.Presentation.csproj" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\DirectoryService.TestData\DirectoryService.TestData.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/DirectoryService/src/DirectoryService.Web/Program.cs
+++ b/DirectoryService/src/DirectoryService.Web/Program.cs
@@ -20,7 +20,8 @@ try
     app.UseExceptionMiddleware();
     app.Configure();
     app.MapControllers();
-    app.Run();
+    await app.RunSeedAsync();
+    await app.RunAsync();
 
 }
 catch (Exception ex)
@@ -28,5 +29,10 @@ catch (Exception ex)
     Log.Fatal(ex, "Application terminated unexpectedly");
 }
 finally {
-    Log.CloseAndFlush();
+   await Log.CloseAndFlushAsync();
+}
+
+namespace DirectoryService.Web
+{
+    public partial class Program;
 }

--- a/DirectoryService/src/General/Errors/FailList.cs
+++ b/DirectoryService/src/General/Errors/FailList.cs
@@ -2,7 +2,7 @@
 
 namespace General.Errors;
 
-public class FailList : IEnumerable<Failure>
+public class FailList : IEnumerable<Failure>, IEquatable<FailList>
 {
     private readonly List<Failure> _failures;
     public int Count => _failures.Count;
@@ -34,4 +34,8 @@ public class FailList : IEnumerable<Failure>
         get => _failures[index]; 
         set => _failures[index] = value;
     }
+
+    public bool Equals(FailList? other) => other is not null && _failures.SequenceEqual(other._failures);
+    public override bool Equals(object? obj) => Equals(obj as FailList);
+    public override int GetHashCode() => _failures.Aggregate(0, HashCode.Combine);
 }

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/CreateDepartmentTests.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/CreateDepartmentTests.cs
@@ -38,7 +38,6 @@ public class CreateDepartmentTests: DirectoryBaseTests
             Assert.NotNull(department);
             Assert.Equal(department.Id, result.Value);
             Assert.True(result.IsSuccess);
-            Assert.NotEqual(Guid.Empty, result.Value);
         });
 
     }

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/CreateDepartmentTests.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/CreateDepartmentTests.cs
@@ -1,0 +1,80 @@
+﻿using CSharpFunctionalExtensions;
+using DirectoryService.Application.Departments;
+using DirectoryService.Contracts.Departments;
+using DirectoryService.Domain.Common.DomainEntityErrors;
+using DirectoryService.Domain.Locations;
+using DirectoryService.Domain.ValueObjects;
+using DirectoryService.Infrastructure;
+using General.Errors;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DirectoryService.IntegrationTests;
+
+public class CreateDepartmentTests: DirectoryBaseTests
+{
+    public CreateDepartmentTests(DirectoryTestWebFactory factory)
+        : base(factory)
+    {
+    }
+    
+    [Fact]
+    public async Task Create_Department_With_Valid_Data_Expected_Success()
+    {
+        var locationId = await CreateLocation();
+        var ctn = CancellationToken.None;
+
+       var result = await ExecuteHandler<CreateDepartmentHandler, Result<Guid, FailList>>((sut) =>
+        {
+            var command = new CreateDepartmentCommand(
+                new CreateDepartmentRequest("тестовое подразделение", "podrazdelenie", [locationId], null));
+            return sut.Handle(command, ctn);
+        });
+
+        await ExecuteInDb(async context =>
+        {
+            var department = await context.Departments.FirstOrDefaultAsync(d => d.Id == result.Value, ctn);
+
+            Assert.NotNull(department);
+            Assert.Equal(department.Id, result.Value);
+            Assert.True(result.IsSuccess);
+            Assert.NotEqual(Guid.Empty, result.Value);
+        });
+
+    }
+
+    [Fact]
+    public async Task Create_Department_With_Invalid_Data_Expect_Failure()
+    {
+        var locationId = Guid.Empty;
+        var ctn = CancellationToken.None;
+        
+        var result = await ExecuteHandler<CreateDepartmentHandler, Result<Guid, FailList>>((sut) =>
+        {
+            var command = new CreateDepartmentCommand(
+                new CreateDepartmentRequest("тестовое подразделение 2", "podraz", [locationId], null));
+            return sut.Handle(command, ctn);
+        });
+        
+        Assert.False(result.IsSuccess); 
+        Assert.Equal(LocationErrors.CollectionNotFound([locationId]).ToFailList(), result.Error);
+    }
+
+    private async Task<Guid> CreateLocation()
+    {
+        var location = Location.Create(
+            LocationName.Create("тестовая локация").Value,
+            Address.Create("Россия", "Москва", "Улица ленина", "56А", 143350).Value,
+            Timezone.Create("Europe/Moscow").Value).Value;
+
+        var result = await ExecuteInDb(context =>
+        {
+            context.Locations.Add(location);
+
+            return context.SaveChangesAsync();
+        });
+        
+        return location.Id;
+    }
+    
+}

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryBaseTests.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryBaseTests.cs
@@ -1,0 +1,50 @@
+﻿using DirectoryService.Application.Abstractions;
+using DirectoryService.Infrastructure;
+using DirectoryService.Infrastructure.Database;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DirectoryService.IntegrationTests;
+
+public class DirectoryBaseTests: IClassFixture<DirectoryTestWebFactory>, IAsyncLifetime
+{
+    private IServiceProvider _services;
+    private Func<Task> _resetDatabase;
+    private Func<Task> _seedDatabase;
+    public DirectoryBaseTests(DirectoryTestWebFactory factory)
+    {
+        _services = factory.Services;
+        _resetDatabase = factory.ResetDataBaseAsync;
+        _seedDatabase = factory.SeedDataBaseAsync;
+    }
+    
+    protected async Task<TResult> ExecuteHandler<THandler, TResult>(
+        Func<THandler, Task<TResult>> action)
+        where THandler : notnull
+    {
+        await using var scope = _services.CreateAsyncScope();
+        var handler = scope.ServiceProvider.GetRequiredService<THandler>();
+        return await action(handler);
+    }
+    
+    protected async Task<T> ExecuteInDb<T>(Func<DirectoryServiceDbContext, Task<T>> action)
+    {
+        await using var initScope = _services.CreateAsyncScope();
+        var context = initScope.ServiceProvider.GetRequiredService<DirectoryServiceDbContext>();
+
+        return await action(context);
+    }
+    
+    protected async Task ExecuteInDb(Func<DirectoryServiceDbContext, Task> action)
+    {
+        await using var initScope = _services.CreateAsyncScope();
+        var context = initScope.ServiceProvider.GetRequiredService<DirectoryServiceDbContext>();
+
+        await action(context);
+    }
+
+    public Task InitializeAsync() => _seedDatabase();
+
+    public Task DisposeAsync() => _resetDatabase();
+    
+}

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryService.IntegrationTests.csproj
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryService.IntegrationTests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="Respawn" Version="7.0.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\DirectoryService.Web\DirectoryService.Web.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryTestWebFactory.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryTestWebFactory.cs
@@ -1,0 +1,97 @@
+﻿using System.Data;
+using DirectoryService.Domain.Common.Constants;
+using DirectoryService.Infrastructure;
+using DirectoryService.Infrastructure.Database;
+using DirectoryService.Web;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Respawn;
+using Testcontainers.PostgreSql;
+
+namespace DirectoryService.IntegrationTests;
+
+public class DirectoryTestWebFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder("postgres")
+        .WithDatabase("ds_tests_db")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    private NpgsqlConnection _dbConnection = null!;
+    private Respawner _respawner = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _dbContainer.StartAsync();
+        
+        await using var scope = Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DirectoryServiceDbContext>();
+        
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        _dbConnection = new NpgsqlConnection(_dbContainer.GetConnectionString());
+        await _dbConnection.OpenAsync();
+        await InitializeRespawnerAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _dbContainer.StopAsync();
+        await _dbContainer.DisposeAsync();
+
+        await _dbConnection.CloseAsync();
+        await _dbConnection.DisposeAsync();
+    }
+    
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        
+        builder.ConfigureAppConfiguration(config =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"ConnectionStrings:{DatabaseConstants.DATABASE}"] = _dbContainer.GetConnectionString()
+            });
+        });
+    }
+    
+    public async Task ResetDataBaseAsync()
+    {
+        await _respawner.ResetAsync(_dbConnection);
+    }
+    
+    public async Task SeedDataBaseAsync()
+    { 
+        await using var scope = Services.CreateAsyncScope();
+        var seeder = scope.ServiceProvider.GetRequiredService<IDataSeeder>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<DirectoryTestWebFactory>>();
+
+        try
+        {
+            await seeder.SeedAsync();
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Failed to seeding in tests");
+        }
+    }
+
+    private async Task InitializeRespawnerAsync()
+    {
+        _respawner = await Respawner.CreateAsync(
+            _dbConnection,
+            new RespawnerOptions()
+        {
+            DbAdapter = DbAdapter.Postgres,
+            SchemasToInclude = ["public"]
+        });
+    }
+    
+}

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryTestWebFactory.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/DirectoryTestWebFactory.cs
@@ -16,12 +16,20 @@ namespace DirectoryService.IntegrationTests;
 
 public class DirectoryTestWebFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Usage", 
+        "CA2213:Disposable fields should be disposed",
+        Justification = "Disposed in IAsyncLifetime.DisposeAsync")]
     private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder("postgres")
         .WithDatabase("ds_tests_db")
         .WithUsername("postgres")
         .WithPassword("postgres")
         .Build();
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Usage", 
+        "CA2213:Disposable fields should be disposed",
+        Justification = "Disposed in IAsyncLifetime.DisposeAsync")]
     private NpgsqlConnection _dbConnection = null!;
     private Respawner _respawner = null!;
 
@@ -40,15 +48,16 @@ public class DirectoryTestWebFactory : WebApplicationFactory<Program>, IAsyncLif
         await InitializeRespawnerAsync();
     }
 
-    public new async Task DisposeAsync()
+    async Task IAsyncLifetime.DisposeAsync()
     {
         await _dbContainer.StopAsync();
         await _dbContainer.DisposeAsync();
-
         await _dbConnection.CloseAsync();
         await _dbConnection.DisposeAsync();
+
+        await DisposeAsync();
     }
-    
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/MoveDepartmentTests.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/MoveDepartmentTests.cs
@@ -1,0 +1,88 @@
+﻿using CSharpFunctionalExtensions;
+using DirectoryService.Application.Departments;
+using DirectoryService.Domain.Common.DomainEntityErrors;
+using DirectoryService.Domain.Departments;
+using DirectoryService.TestData.Fixtures;
+using General.Errors;
+using Microsoft.EntityFrameworkCore;
+
+namespace DirectoryService.IntegrationTests;
+
+public class MoveDepartmentTests: DirectoryBaseTests
+{
+    public MoveDepartmentTests(DirectoryTestWebFactory factory) 
+        : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task Move_Department_With_Valid_Data_Expected_Success()
+    {
+        var sourceRecruiting = DepartmentFixtures.Recruiting;
+        var sourceParentIdRecruiting = sourceRecruiting.ParentId;
+
+        var sourceInfraDevOps = DepartmentFixtures.InfraDevOps;
+        var sourceSoftwareDev = DepartmentFixtures.SoftwareDev;
+        var sourceIt = DepartmentFixtures.IT;
+        
+        var cnt = CancellationToken.None;
+        
+        var res1 = await ExecuteHandler<MoveDepartmentHandler, Result<Guid, FailList>>(sut =>
+            sut.Handle(new MoveDepartmentCommand(DepartmentFixtures.RecruitingId, null), cnt));
+
+        var res2 = await ExecuteHandler<MoveDepartmentHandler, Result<Guid, FailList>>(sut =>
+            sut.Handle(new MoveDepartmentCommand(DepartmentFixtures.InfraDevOpsId, DepartmentFixtures.ItId), cnt));
+        
+        Assert.True(res1.IsSuccess);
+        Assert.NotNull(sourceParentIdRecruiting);
+        
+        Assert.True(res2.IsSuccess);
+        Assert.Equal(sourceInfraDevOps.ParentId, sourceSoftwareDev.Id);
+        
+        var recruiting = await ExecuteInDb(async context =>
+                await context.Departments.FirstOrDefaultAsync(d => d.Id == DepartmentFixtures.RecruitingId, cnt));
+        
+        Assert.NotEqual(sourceRecruiting.Path, recruiting?.Path);
+        Assert.Equal(recruiting?.Path.Value, recruiting?.Identifier.Value);
+        Assert.NotEqual(recruiting?.ParentId, sourceParentIdRecruiting);
+        Assert.Null(recruiting?.ParentId);
+        
+        var devops = await ExecuteInDb(async context => await context.Departments.FirstOrDefaultAsync(d => d.Id == DepartmentFixtures.InfraDevOpsId, cnt));
+        
+        Assert.NotEqual(devops?.Path, sourceInfraDevOps.Path);
+        Assert.NotEqual(devops?.ParentId, sourceSoftwareDev.Id);
+        Assert.Equal(sourceIt.Id, devops?.ParentId);
+        Assert.Equal(devops?.Path.Value, $"{sourceIt.Path.Value}.{devops?.Identifier.Value}");
+    }
+    
+    [Fact]
+    public async Task Move_Department_With_Invalid_Data_Expected_Failure()
+    {
+        var command1 = new MoveDepartmentCommand(Guid.NewGuid(), null);
+        var command2 = new MoveDepartmentCommand(DepartmentFixtures.RecruitingId, Guid.NewGuid());
+        var command3 = new MoveDepartmentCommand(DepartmentFixtures.HrId, DepartmentFixtures.RecruitingId);
+        var command4 = new MoveDepartmentCommand(DepartmentFixtures.HrId, DepartmentFixtures.HrId);
+        
+        var cnt = CancellationToken.None;
+        var conflictFailure = Failure
+            .Conflict("A descendant department cannot be set as a parent", "department.path.conflict")
+            .ToFailList();
+        var validationFailure =
+            Failure.Validation("Department cannot be moved to itself", "department.request.invalid");
+        
+        var res1 = await ExecuteHandler<MoveDepartmentHandler, Result<Guid, FailList>>(sut =>
+            sut.Handle(command1, cnt));
+        var res2 = await ExecuteHandler<MoveDepartmentHandler, Result<Guid, FailList>>(sut =>
+            sut.Handle(command2, cnt));
+        var res3 = await ExecuteHandler<MoveDepartmentHandler, Result<Guid, FailList>>(sut =>
+            sut.Handle(command3, cnt));
+        var res4 = await ExecuteHandler<MoveDepartmentHandler, Result<Guid, FailList>>(sut =>
+            sut.Handle(command4, cnt));
+        
+        // Assert.True(res1.IsFailure && res2.IsFailure && res3.IsFailure && res4.IsFailure);
+        Assert.Equal(res1.Error, DepartmentErrors.NotFound(command1.departmentId).ToFailList());
+        Assert.Equal(res2.Error, DepartmentErrors.NotFound(command2.parentId!.Value).ToFailList());
+        Assert.Equal(res3.Error, conflictFailure);
+        Assert.Equal(res4.Error, validationFailure.ToFailList());
+    }
+}

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/MoveDepartmentTests.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/MoveDepartmentTests.cs
@@ -79,7 +79,7 @@ public class MoveDepartmentTests: DirectoryBaseTests
         var res4 = await ExecuteHandler<MoveDepartmentHandler, Result<Guid, FailList>>(sut =>
             sut.Handle(command4, cnt));
         
-        // Assert.True(res1.IsFailure && res2.IsFailure && res3.IsFailure && res4.IsFailure);
+        Assert.True(res1.IsFailure && res2.IsFailure && res3.IsFailure && res4.IsFailure);
         Assert.Equal(res1.Error, DepartmentErrors.NotFound(command1.departmentId).ToFailList());
         Assert.Equal(res2.Error, DepartmentErrors.NotFound(command2.parentId!.Value).ToFailList());
         Assert.Equal(res3.Error, conflictFailure);

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/UpdateDepartmentLocationsTests.cs
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/UpdateDepartmentLocationsTests.cs
@@ -1,0 +1,77 @@
+﻿using CSharpFunctionalExtensions;
+using DirectoryService.Application.Departments;
+using DirectoryService.Domain.Common;
+using DirectoryService.Domain.Common.DomainEntityErrors;
+using DirectoryService.Domain.Departments;
+using DirectoryService.TestData.Fixtures;
+using General.Errors;
+using Microsoft.EntityFrameworkCore;
+using Xunit.Sdk;
+
+namespace DirectoryService.IntegrationTests;
+
+public class UpdateDepartmentLocationsTests : DirectoryBaseTests
+{
+    public UpdateDepartmentLocationsTests(DirectoryTestWebFactory factory) 
+        : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task Update_DepartmentLocations_With_Valid_Data_Expected_Success()
+    {
+        var cnt = CancellationToken.None;
+        var res = await ExecuteHandler<UpdateDepartmentLocationsHandler, Result<Guid, FailList>>(sut => sut.Handle(
+            new UpdateDepartmentLocationsCommand(DepartmentFixtures.AccountingId, [LocationFixtures.CologneId]),
+            cnt));
+
+        Assert.True(res.IsSuccess);
+        Assert.Equal(DepartmentFixtures.AccountingId, res.Value);
+
+        var departmentId = res.Value;
+
+        await ExecuteInDb(async context =>
+        {
+            DepartmentLocation? departmentLocation = await context.DepartmentLocations
+                .FirstOrDefaultAsync(
+                    dl => dl.DepartmentId == departmentId && dl.LocationId == LocationFixtures.CologneId,
+                    cnt);
+        
+            Assert.NotNull(departmentLocation);
+        });
+    }
+
+    [Fact]
+    public async Task Update_DepartmentLocations_With_Invalid_Data_Expected_Failure()
+    {
+        var cnt = CancellationToken.None;
+
+        Guid invalidDepartmentId = Guid.NewGuid(); 
+        List<Guid> invalidLocationIds = [Guid.NewGuid(), Guid.NewGuid()];
+        var res1 = await ExecuteHandler<UpdateDepartmentLocationsHandler, Result<Guid, FailList>>(
+            sut => sut.Handle(
+                new UpdateDepartmentLocationsCommand(invalidDepartmentId, [LocationFixtures.MunichId, LocationFixtures.AmsterdamId]),
+                cnt));
+
+        var res2 = await ExecuteHandler<UpdateDepartmentLocationsHandler, Result<Guid, FailList>>(
+            sut => sut.Handle(
+            new UpdateDepartmentLocationsCommand(DepartmentFixtures.HrId, invalidLocationIds),
+            cnt));
+
+        var res3 = await ExecuteHandler<UpdateDepartmentLocationsHandler, Result<Guid, FailList>>(sut =>
+            sut.Handle(
+                new UpdateDepartmentLocationsCommand(Guid.Empty, [Guid.Empty, LocationFixtures.ZurichId]),
+                cnt));
+
+        FailList errors = new FailList([
+            Failure.Validation("The Department ID must not be empty.", "department-id.invalid"),
+            CommonErrors.CollectionItemsInvalid("Location-id")
+        ]);
+        
+        Assert.True(res1.IsFailure && res2.IsFailure && res3.IsFailure);
+        Assert.Equal(res1.Error, DepartmentErrors.NotFound(invalidDepartmentId).ToFailList());
+        Assert.Equal(res2.Error, LocationErrors.CollectionNotFound(invalidLocationIds).ToFailList());
+        Assert.Equal(res3.Error, errors);
+    }
+    
+}

--- a/DirectoryService/src/tests/DirectoryService.IntegrationTests/xunit.runner.json
+++ b/DirectoryService/src/tests/DirectoryService.IntegrationTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
- Благодаря тестам, поправлены баги которые я не заметил, например проверка что новый parent не является наследником.
- Добавлен отдельный проект, в котором реализован Seeder и так же Fixtures, надеюсь это ок. Все таки пришлось добавлять ссылку в Web, но я сделал так что при Release, в сборку не попадет.
- Данные сидируются при Developer и если в БД нет Locations. А так же каждый раз при тестах, когда Dispose одного теста сбрасывает состояние БД, Inizialise в тот момент накатывает миграции снова.
- Так же для кастомной коллекции FailList реализован IEquatable<FailList> интерфейс, что бы сравнение в тестах было корректным
- Ну и небольшие поправки тоже внесены